### PR TITLE
Enable optimization of the CI builds.

### DIFF
--- a/.travis.scripts/test.sh
+++ b/.travis.scripts/test.sh
@@ -18,9 +18,9 @@ apt-get clean && rm -rf /var/lib/apt/lists/*
 
 sync
 
-sed -i -e '5a set(CMAKE_C_FLAGS "-Wall -Werror")' \
+sed -i -e '5a set(CMAKE_C_FLAGS "-Wall -Werror -O2")' \
   /opt/ros/${ROS_DISTRO}/share/catkin/cmake/toplevel.cmake
-sed -i -e '5a set(CMAKE_CXX_FLAGS "-Wall -Werror")' \
+sed -i -e '5a set(CMAKE_CXX_FLAGS "-Wall -Werror -O2")' \
   /opt/ros/${ROS_DISTRO}/share/catkin/cmake/toplevel.cmake
 
 CM_OPTIONS=""


### PR DESCRIPTION
Navigation simulation test randomly timed out
due to the load increase of the travis-ci.
This commit adds -O2 to speed up planning on tests.