### PR TITLE
planner_cspace: use frame_id of incoming message to set dummy robot pose

### DIFF
--- a/planner_cspace/src/dummy_robot.cpp
+++ b/planner_cspace/src/dummy_robot.cpp
@@ -57,10 +57,10 @@ protected:
   }
   void cbInit(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr &msg)
   {
-    tf::StampedTransform trans_map_odom;
+    tf::StampedTransform trans_msg_odom;
     try
     {
-      tfl_.lookupTransform(msg->header.frame_id, "odom", ros::Time(0), trans_map_odom);
+      tfl_.lookupTransform(msg->header.frame_id, "odom", ros::Time(0), trans_msg_odom);
     }
     catch (tf::TransformException &e){
       ROS_WARN("%s", e.what());
@@ -69,7 +69,7 @@ protected:
 
     tf::Pose pose;
     tf::poseMsgToTF(msg->pose.pose, pose);
-    const tf::Transform trans_odom_baselink = trans_map_odom.inverse() * pose;
+    const tf::Transform trans_odom_baselink = trans_msg_odom.inverse() * pose;
 
     x_ = trans_odom_baselink.getOrigin().x();
     y_ = trans_odom_baselink.getOrigin().y();

--- a/planner_cspace/src/dummy_robot.cpp
+++ b/planner_cspace/src/dummy_robot.cpp
@@ -62,7 +62,8 @@ protected:
     {
       tfl_.lookupTransform(msg->header.frame_id, "odom", ros::Time(0), trans_msg_odom);
     }
-    catch (tf::TransformException &e){
+    catch (tf::TransformException &e)
+    {
       ROS_WARN("%s", e.what());
       return;
     }


### PR DESCRIPTION
Fixes #144 

This PR uses TF from frame_id of incoming message to base_link to estimate initial robot pose(odom to base_link).
