### PR TITLE
Compile with PCL_NO_PRECOMPILE

### DIFF
--- a/map_organizer/CMakeLists.txt
+++ b/map_organizer/CMakeLists.txt
@@ -65,6 +65,12 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -DROS_DISTRO_$ENV{ROS_DISTRO}=1")
 
+# Binary installed pcl provided by Linux distro is built with -march=native
+# which causes a lot of compatibility problems.
+# Define PCL_NO_PRECOMPILE to disable using the binary version.
+add_definitions(-DPCL_NO_PRECOMPILE)
+
+
 add_executable(pointcloud_to_maps src/pointcloud_to_maps.cpp)
 target_link_libraries(pointcloud_to_maps ${catkin_LIBRARIES} ${PCL_LIBRARIES})
 add_dependencies(pointcloud_to_maps ${catkin_EXPORTED_TARGETS})

--- a/obj_to_pointcloud/CMakeLists.txt
+++ b/obj_to_pointcloud/CMakeLists.txt
@@ -53,6 +53,12 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
+# Binary installed pcl provided by Linux distro is built with -march=native
+# which causes a lot of compatibility problems.
+# Define PCL_NO_PRECOMPILE to disable using the binary version.
+add_definitions(-DPCL_NO_PRECOMPILE)
+
+
 add_executable(obj_to_pointcloud src/obj_to_pointcloud.cpp)
 target_link_libraries(obj_to_pointcloud ${catkin_LIBRARIES} ${PCL_LIBRARIES})
 add_dependencies(obj_to_pointcloud ${catkin_EXPORTED_TARGETS})

--- a/safety_limiter/CMakeLists.txt
+++ b/safety_limiter/CMakeLists.txt
@@ -51,6 +51,12 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
+# Binary installed pcl provided by Linux distro is built with -march=native
+# which causes a lot of compatibility problems.
+# Define PCL_NO_PRECOMPILE to disable using the binary version.
+add_definitions(-DPCL_NO_PRECOMPILE)
+
+
 add_executable(safety_limiter src/safety_limiter.cpp)
 target_link_libraries(safety_limiter ${catkin_LIBRARIES} ${PCL_LIBRARIES})
 


### PR DESCRIPTION
Binary installed pcl provided by Linux distro is built with -march=native
which causes a lot of compatibility problems.
Define PCL_NO_PRECOMPILE to disable using the binary version.

ref: https://github.com/at-wat/mcl_3dl/pull/161