### PR TITLE
planner_cspace: add diagnostics to planner node

### DIFF
--- a/planner_cspace/CMakeLists.txt
+++ b/planner_cspace/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED
     roscpp
 
     actionlib
+    diagnostic_updater
     geometry_msgs
     move_base_msgs
     nav_msgs
@@ -28,6 +29,7 @@ catkin_package(
     roscpp
 
     actionlib
+    diagnostic_updater
     geometry_msgs
     move_base_msgs
     nav_msgs

--- a/planner_cspace/package.xml
+++ b/planner_cspace/package.xml
@@ -16,6 +16,7 @@
   <test_depend>rosunit</test_depend>
 
   <depend>actionlib</depend>
+  <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
   <depend>move_base_msgs</depend>
   <depend>nav_msgs</depend>

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1248,7 +1248,7 @@ public:
     cnt_stuck_ = 0;
 
     diag_updater_.setHardwareID("none");
-    diag_updater_.add("Status", this, &Planner3dNode::diagnoseStatus);
+    diag_updater_.add("Path Planner Status", this, &Planner3dNode::diagnoseStatus);
 
     act_->start();
   }

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -31,6 +31,7 @@
 
 #include <costmap_cspace_msgs/CSpace3D.h>
 #include <costmap_cspace_msgs/CSpace3DUpdate.h>
+#include <diagnostic_updater/diagnostic_updater.h>
 #include <nav_msgs/GetPlan.h>
 #include <nav_msgs/Path.h>
 #include <planner_cspace_msgs/PlannerStatus.h>
@@ -219,6 +220,8 @@ protected:
 
   MotionCache<Astar::Vec, Astar::Vecf>::Ptr motion_cache_;
   MotionCache<Astar::Vec, Astar::Vecf>::Ptr motion_cache_linear_;
+
+  diagnostic_updater::Updater diag_updater_;
 
   bool cbForget(std_srvs::EmptyRequest &req,
                 std_srvs::EmptyResponse &res)
@@ -1243,6 +1246,9 @@ public:
     escaping_ = false;
     cnt_stuck_ = 0;
 
+    diag_updater_.setHardwareID("none");
+    diag_updater_.add("Status", this, &Planner3dNode::diagnoseStatus);
+
     act_->start();
   }
   void spin()
@@ -1342,6 +1348,7 @@ public:
         pub_path_.publish(path);
       }
       pub_status_.publish(status_);
+      diag_updater_.force_update();
     }
   }
 
@@ -1781,6 +1788,24 @@ protected:
     }
 
     return cost;
+  }
+
+  void diagnoseStatus(diagnostic_updater::DiagnosticStatusWrapper &stat)
+  {
+    if (status_.error == planner_cspace_msgs::PlannerStatus::IN_ROCK)
+    {
+      stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "The robot is in rock.");
+    }
+    else if (status_.error == planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND)
+    {
+      stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "Path not found.");
+    }
+    else
+    {
+      stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Going well.");
+    }
+    stat.addf("status", "%u", status_.status);
+    stat.addf("error", "%u", status_.error);
   }
 };
 

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1349,7 +1349,7 @@ public:
         pub_path_.publish(path);
       }
       pub_status_.publish(status_);
-      diag_updater_.update();
+      diag_updater_.force_update();
     }
   }
 

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -386,6 +386,7 @@ protected:
       }
       status_.status = planner_cspace_msgs::PlannerStatus::DOING;
       pub_status_.publish(status_);
+      diag_updater_.update();
     }
     else
     {
@@ -1348,7 +1349,7 @@ public:
         pub_path_.publish(path);
       }
       pub_status_.publish(status_);
-      diag_updater_.force_update();
+      diag_updater_.update();
     }
   }
 


### PR DESCRIPTION
This PR adds diagnostic_updater to publish /diagnostics topic periodically.
As far as I know, the planner status is composed to /planner/status topic, so the updater checks only the topic.

The output of  `rostopic echo /diagnostics` 
e.g.
- going well
```
---
header: 
  seq: 432
  stamp: 
    secs: 1538448072
    nsecs:  44865701
  frame_id: ''
status: 
  - 
    level: 0
    name: "planner_3d: Status"
    message: "Going well."
    hardware_id: "none"
    values: 
      - 
        key: "status"
        value: "1"
      - 
        key: "error"
        value: "0"
---
```

- path not found

```
---
header: 
  seq: 103
  stamp: 
    secs: 1538447857
    nsecs: 596350716
  frame_id: ''
status: 
  - 
    level: 2
    name: "planner_3d: Status"
    message: "Path not found."
    hardware_id: "none"
    values: 
      - 
        key: "status"
        value: "1"
      - 
        key: "error"
        value: "2"
---

```
