### PR TITLE
trajectory_tracker: add tolerance to InPlaceTurn

### DIFF
--- a/trajectory_tracker/test/src/test_trajectory_tracker.cpp
+++ b/trajectory_tracker/test/src/test_trajectory_tracker.cpp
@@ -264,9 +264,9 @@ TEST_F(TrajectoryTrackerTest, InPlaceTurn)
         ros::spinOnce();
 
         if (cmd_vel_)
-          ASSERT_GT(cmd_vel_->angular.z * ang, 0);
+          ASSERT_GT(cmd_vel_->angular.z * ang, -1e-2);
         if (status_)
-          ASSERT_LT(status_->angle_remains * ang, 0);
+          ASSERT_LT(status_->angle_remains * ang, 1e-2);
 
         if (status_->status == trajectory_tracker_msgs::TrajectoryTrackerStatus::GOAL)
           break;


### PR DESCRIPTION
```
[ROSTEST]-----------------------------------------------------------------------
[trajectory_tracker.rosunit-test_trajectory_tracker/StraightStop][passed]
[trajectory_tracker.rosunit-test_trajectory_tracker/StraightVelocityChange][passed]
[trajectory_tracker.rosunit-test_trajectory_tracker/CurveFollow][passed]
[trajectory_tracker.rosunit-test_trajectory_tracker/InPlaceTurn][FAILURE]-------
/catkin_ws/src/neonavigation/trajectory_tracker/test/src/test_trajectory_tracker.cpp:334
Expected: (cmd_vel_->angular.z * ang) > (0), actual: -4.54747e-14 vs 0
--------------------------------------------------------------------------------
```