### PR TITLE
track_odometry: set missing child_frame_id in tf_projection

### DIFF
--- a/track_odometry/src/tf_projection.cpp
+++ b/track_odometry/src/tf_projection.cpp
@@ -89,6 +89,7 @@ public:
         trans_out.transform.rotation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0.0, 0.0, 1.0), yaw));
       }
       trans_out.header.stamp = trans.stamp_ + ros::Duration(tf_tolerance_);
+      trans_out.child_frame_id = frames_["frame"];
 
       tf_broadcaster_.sendTransform(trans_out);
     }

--- a/track_odometry/test/CMakeLists.txt
+++ b/track_odometry/test/CMakeLists.txt
@@ -7,3 +7,10 @@ add_rostest_gtest(test_track_odometry
 )
 target_link_libraries(test_track_odometry ${catkin_LIBRARIES})
 add_dependencies(test_track_odometry track_odometry)
+
+add_rostest_gtest(test_tf_projection_node
+  test/tf_projection_rostest.test
+  src/test_tf_projection_node.cpp
+)
+target_link_libraries(test_tf_projection_node ${catkin_LIBRARIES})
+add_dependencies(test_tf_projection_node tf_projection)

--- a/track_odometry/test/src/test_tf_projection_node.cpp
+++ b/track_odometry/test/src/test_tf_projection_node.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019, the neonavigation authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ros/ros.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <gtest/gtest.h>
+
+TEST(TfProjection, ProjectionTransform)
+{
+  tf2_ros::Buffer tfbuf;
+  tf2_ros::TransformListener tfl(tfbuf);
+  EXPECT_TRUE(tfbuf.canTransform("map", "base_link_projected", ros::Time(0), ros::Duration(1.0)));
+
+  geometry_msgs::TransformStamped out;
+  try
+  {
+    out = tfbuf.lookupTransform("map", "base_link_projected", ros::Time(0), ros::Duration(1.0));
+  }
+  catch (tf2::TransformException &e)
+  {
+    FAIL() << e.what();
+  }
+  ASSERT_EQ(out.transform.translation.x, 1);
+  ASSERT_EQ(out.transform.translation.y, 2);
+  ASSERT_EQ(out.transform.translation.z, 0);
+  ASSERT_EQ(out.transform.rotation.x, 0);
+  ASSERT_EQ(out.transform.rotation.y, 0);
+  ASSERT_NEAR(out.transform.rotation.z, 0.7071, 1e-4);
+  ASSERT_NEAR(out.transform.rotation.w, 0.7071, 1e-4);
+  ASSERT_EQ(out.header.frame_id, "map");
+  ASSERT_EQ(out.child_frame_id, "base_link_projected");
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "test_tf_projection_node");
+
+  return RUN_ALL_TESTS();
+}

--- a/track_odometry/test/test/tf_projection_rostest.test
+++ b/track_odometry/test/test/tf_projection_rostest.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="neonavigation_compatible" value="1" />
+
+  <test test-name="test_tf_projection_node" pkg="track_odometry" type="test_tf_projection_node" />
+
+  <node pkg="track_odometry" type="tf_projection" name="tf_projection">
+    <param name="base_link_frame" value="base_link" />
+    <param name="projection_frame" value="map" />
+    <param name="target_frame" value="map" />
+    <param name="frame" value="base_link_projected" />
+  </node>
+
+  <node pkg="tf2_ros" type="static_transform_publisher" name="test_static_pub" args="1 2 3 0 0 0.7071 0.7071 /map /base_link" />
+</launch>


### PR DESCRIPTION
Set missing `child_frame_id` field in `geometry_msgs::TransformStamped`.
This line was incorrectly deleted in the TF2 migration commit. https://github.com/at-wat/neonavigation/commit/daa67739c2428359f3276098379a1c3ef91a8fa2
