### PR TITLE
safety_limiter: fix backward motion limit

### DIFF
--- a/safety_limiter/src/safety_limiter.cpp
+++ b/safety_limiter/src/safety_limiter.cpp
@@ -372,9 +372,9 @@ protected:
       if (t != 0)
       {
         d_col += twist_.linear.x * dt_;
-        d_escape_remain -= twist_.linear.x * dt_;
+        d_escape_remain -= std::abs(twist_.linear.x) * dt_;
         yaw_col += twist_.angular.z * dt_;
-        yaw_escape_remain -= twist_.angular.z * dt_;
+        yaw_escape_remain -= std::abs(twist_.angular.z) * dt_;
         move = move * motion;
         move_inv = move_inv * motion_inv;
       }

--- a/safety_limiter/test/src/test_safety_limiter.cpp
+++ b/safety_limiter/test/src/test_safety_limiter.cpp
@@ -268,7 +268,7 @@ TEST_F(SafetyLimiterTest, SafetyLimitLinear)
         en = true;
       publishSinglePointPointcloud2(0.5, 0, 0, "base_link", ros::Time::now());
       publishWatchdogReset();
-      publishTwist(vel, ((i % 3) - 1.0) * 0.01);
+      publishTwist(vel, ((i % 5) - 2.0) * 0.01);
 
       wait.sleep();
       ros::spinOnce();
@@ -317,7 +317,7 @@ TEST_F(SafetyLimiterTest, SafetyLimitLinearBackward)
         en = true;
       publishSinglePointPointcloud2(-2.5, 0, 0, "base_link", ros::Time::now());
       publishWatchdogReset();
-      publishTwist(vel, ((i % 3) - 1.0) * 0.01);
+      publishTwist(vel, ((i % 5) - 2.0) * 0.01);
 
       wait.sleep();
       ros::spinOnce();

--- a/safety_limiter/test/src/test_safety_limiter.cpp
+++ b/safety_limiter/test/src/test_safety_limiter.cpp
@@ -268,7 +268,56 @@ TEST_F(SafetyLimiterTest, SafetyLimitLinear)
         en = true;
       publishSinglePointPointcloud2(0.5, 0, 0, "base_link", ros::Time::now());
       publishWatchdogReset();
-      publishTwist(vel, (i % 3) * 0.01);
+      publishTwist(vel, ((i % 3) - 1.0) * 0.01);
+
+      wait.sleep();
+      ros::spinOnce();
+    }
+    ASSERT_TRUE(received);
+    sub_cmd_vel.shutdown();
+  }
+}
+
+TEST_F(SafetyLimiterTest, SafetyLimitLinearBackward)
+{
+  ros::Rate wait(20.0);
+
+  // Skip initial state
+  for (size_t i = 0; i < 10 && ros::ok(); ++i)
+  {
+    publishSinglePointPointcloud2(-2.5, 0, 0, "base_link", ros::Time::now());
+    publishWatchdogReset();
+
+    wait.sleep();
+    ros::spinOnce();
+  }
+
+  for (float vel = 0.0; vel > -2.0; vel -= 0.4)
+  {
+    // 1.0 m/ss, obstacle at -2.5 m: limited to -1.0 m/s
+    bool received = false;
+    bool failed = false;
+    bool en = false;
+    const boost::function<void(const geometry_msgs::Twist::ConstPtr&)> cb_cmd_vel =
+        [&received, &failed, &en, vel](const geometry_msgs::Twist::ConstPtr& msg) -> void
+    {
+      if (!en)
+        return;
+      const float expected_vel = std::max<float>(vel, -1.0);
+      received = true;
+      failed = true;
+      ASSERT_NEAR(msg->linear.x, expected_vel, 1e-1);
+      failed = false;
+    };
+    ros::Subscriber sub_cmd_vel = nh_.subscribe("cmd_vel", 1, cb_cmd_vel);
+
+    for (size_t i = 0; i < 10 && ros::ok() && !failed; ++i)
+    {
+      if (i > 5)
+        en = true;
+      publishSinglePointPointcloud2(-2.5, 0, 0, "base_link", ros::Time::now());
+      publishWatchdogReset();
+      publishTwist(vel, ((i % 3) - 1.0) * 0.01);
 
       wait.sleep();
       ros::spinOnce();


### PR DESCRIPTION
This PR fixes possibility to be collided to obstacle if the robot moves to backward.

Internally, If the robot moves to backward(`twist_.linear.x < 0`) and rotates ~~counter~~ clockwise(`twist_.angular.z < 0`), the following line would be false, then robot will not limit velocity even if obstacle is placed behind the robot.
https://github.com/at-wat/neonavigation/blob/master/safety_limiter/src/safety_limiter.cpp#L423

This PR fixes `*_escape_remain` value that should be negative regardless of robot velocity, except if the robot is already collided.