### PR TITLE
safety_limiter: increase simulation test publish rate

### DIFF
--- a/safety_limiter/test/src/test_safety_limiter.cpp
+++ b/safety_limiter/test/src/test_safety_limiter.cpp
@@ -454,7 +454,7 @@ TEST_F(SafetyLimiterTest, NoCollision)
 
 TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulation)
 {
-  const float dt = 0.05;
+  const float dt = 0.02;
   ros::Rate wait(1.0 / dt);
 
   const float velocities[] =

--- a/safety_limiter/test/src/test_safety_limiter2.cpp
+++ b/safety_limiter/test/src/test_safety_limiter2.cpp
@@ -40,7 +40,7 @@
 
 TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulationWithMargin)
 {
-  const float dt = 0.05;
+  const float dt = 0.02;
   ros::Rate wait(1.0 / dt);
 
   const float velocities[] =


### PR DESCRIPTION
Simulation based safety_limiter test exceeds threshold a little bit on ROS official buildfarm.
It might be caused by the huge amount of resuming jobs stored during buildfarm outage.

The error can be reproduced locally by running benchmark software occupying 100% of CPU during rostest.