### PR TITLE
planner_cspace: publish empty path immediately after planning aborted

### DIFF
--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1352,7 +1352,10 @@ public:
           {
             status_.status = planner_cspace_msgs::PlannerStatus::DONE;
             has_goal_ = false;
+
+            publishEmptyPath();
             ROS_INFO("Path plan finished");
+
             if (act_->isActive())
               act_->setSucceeded(move_base_msgs::MoveBaseResult(), "Goal reached.");
           }
@@ -1368,11 +1371,13 @@ public:
             status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
             status_.status = planner_cspace_msgs::PlannerStatus::DONE;
             has_goal_ = false;
+
+            publishEmptyPath();
+            ROS_ERROR("Exceeded max_retry_num:%d", max_retry_num_);
+
             if (act_->isActive())
               act_->setAborted(
                   move_base_msgs::MoveBaseResult(), "Goal is in Rock");
-
-            ROS_ERROR("Exceeded max_retry_num:%d", max_retry_num_);
             continue;
           }
           else

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1352,8 +1352,8 @@ public:
           {
             status_.status = planner_cspace_msgs::PlannerStatus::DONE;
             has_goal_ = false;
-
-            publishEmptyPath();
+            // Don't publish empty path here in order a path follower
+            // to minimize the error to the desired final pose
             ROS_INFO("Path plan finished");
 
             if (act_->isActive())


### PR DESCRIPTION
This PR make a robot stop immediately after path planning completed; succeeded or aborted.

Without this, the robot may still rotate for a while until [next loop](https://github.com/at-wat/neonavigation/blob/master/planner_cspace/src/planner_3d.cpp#L1290).
e.g. rotates at least 0.25 sec. by the default parameter `freq=4Hz`).