### PR TITLE
planner_cspace: fix incomplete output path after search timeout

### DIFF
--- a/planner_cspace/include/planner_cspace/grid_astar.h
+++ b/planner_cspace/include/planner_cspace/grid_astar.h
@@ -397,12 +397,13 @@ protected:
     }
     return findPath(ss_normalized, e, path);
   }
-  bool findPath(const Vec& s, const Vec& e, std::list<Vec>& path)
+  bool findPath(const Vec& s, const Vec& e, std::list<Vec>& path) const
   {
     return findPath(std::vector<VecWithCost>(1, VecWithCost(s)), e, path);
   }
-  bool findPath(const std::vector<VecWithCost>& ss, const Vec& e, std::list<Vec>& path)
+  bool findPath(const std::vector<VecWithCost>& ss, const Vec& e, std::list<Vec>& path) const
   {
+    auto parents = parents_;
     Vec n = e;
     while (true)
     {
@@ -419,12 +420,15 @@ protected:
       }
       if (found)
         break;
-      if (parents_.find(n) == parents_.end())
+      if (parents.find(n) == parents.end())
+      {
+        ROS_WARN("Path is incomplete or looped");
         return false;
+      }
 
       const Vec child = n;
-      n = parents_[child];
-      parents_.erase(child);
+      n = parents[child];
+      parents.erase(child);
     }
     return true;
   }

--- a/planner_cspace/include/planner_cspace/grid_astar.h
+++ b/planner_cspace/include/planner_cspace/grid_astar.h
@@ -421,10 +421,7 @@ protected:
       if (found)
         break;
       if (parents.find(n) == parents.end())
-      {
-        ROS_WARN("Path is incomplete or looped");
         return false;
-      }
 
       const Vec child = n;
       n = parents[child];

--- a/planner_cspace/include/planner_cspace/grid_astar.h
+++ b/planner_cspace/include/planner_cspace/grid_astar.h
@@ -403,7 +403,7 @@ protected:
   }
   bool findPath(const std::vector<VecWithCost>& ss, const Vec& e, std::list<Vec>& path) const
   {
-    auto parents = parents_;
+    std::unordered_map<Vec, Vec, Vec> parents = parents_;
     Vec n = e;
     while (true)
     {

--- a/planner_cspace/test/src/test_grid_astar.cpp
+++ b/planner_cspace/test/src/test_grid_astar.cpp
@@ -168,7 +168,7 @@ public:
   {
     return parents_;
   }
-  bool findPath(const Vec& s, const Vec& e, std::list<Vec>& path)
+  bool findPath(const Vec& s, const Vec& e, std::list<Vec>& path) const
   {
     return GridAstar::findPath(s, e, path);
   }
@@ -221,13 +221,17 @@ TEST(GridAstar, FindPath)
   as.parentMap()[Vec(2)] = Vec(1);
   as.parentMap()[Vec(1)] = Vec(0);
 
-  std::list<Vec> path;
-  ASSERT_TRUE(as.findPath(Vec(0), Vec(2), path));
-  ASSERT_EQ(path.size(), 3u);
-  auto it = path.cbegin();
-  ASSERT_EQ(*(it++), Vec(0));
-  ASSERT_EQ(*(it++), Vec(1));
-  ASSERT_EQ(*it, Vec(2));
+  // findPath must return same result for multiple calls
+  for (int i = 0; i < 2; ++i)
+  {
+    std::list<Vec> path;
+    ASSERT_TRUE(as.findPath(Vec(0), Vec(2), path));
+    ASSERT_EQ(path.size(), 3u);
+    auto it = path.cbegin();
+    ASSERT_EQ(*(it++), Vec(0));
+    ASSERT_EQ(*(it++), Vec(1));
+    ASSERT_EQ(*it, Vec(2));
+  }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
`GridAstar::findPath` is called on search timeout to pass the progress result to `cbProgress`.
findPath must be const member to guarantee it never breaks intermediate search state.

---
fix #356 
like:
![Screenshot from 2019-07-23 02-25-49](https://user-images.githubusercontent.com/8390204/61651630-3a7ee000-acf1-11e9-8fda-b78d71e309d9.png)
