### PR TITLE
planner_cspace: clear hysteresis if new obstacle is on the previous path

### DIFF
--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -841,6 +841,8 @@ protected:
       }
     }
 
+    bool clear_hysteresis(false);
+
     {
       const Astar::Vec center(
           static_cast<int>(msg->width / 2), static_cast<int>(msg->height / 2), 0);
@@ -862,6 +864,8 @@ protected:
             const char c = msg->data[addr];
             if (c < cost_min)
               cost_min = c;
+            if (c == 100 && !clear_hysteresis && cm_hyst_[gp + p] == 0)
+              clear_hysteresis = true;
           }
           p[2] = 0;
           if (cost_min > cm_rough_[gp_rough + p])
@@ -909,6 +913,13 @@ protected:
         }
       }
     }
+
+    if (clear_hysteresis)
+    {
+      ROS_DEBUG("Previous path may make collision to the obstacle. Clearing hysteresis map.");
+      cm_hyst_.clear(100);
+    }
+
     if (!has_goal_ || !has_start_)
       return;
 

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1752,7 +1752,13 @@ protected:
         {
           if (it != it_prev)
           {
-            if (lroundf((*it)[2]) == p[2] || lroundf((*it_prev)[2]) == p[2])
+            int yaw = lroundf((*it)[2]) % map_info_.angle;
+            int yaw_prev = lroundf((*it_prev)[2]) % map_info_.angle;
+            if (yaw < 0)
+              yaw += map_info_.angle;
+            if (yaw_prev < 0)
+              yaw_prev += map_info_.angle;
+            if (yaw == p[2] || yaw_prev == p[2])
             {
               const float d =
                   CyclicVecFloat<3, 2>(p).distLinestrip2d(*it_prev, *it);

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -922,6 +922,7 @@ protected:
     {
       ROS_INFO("Previous path may cause collision to the obstacle. Clearing hysteresis map.");
       cm_hyst_.clear(100);
+      has_hysteresis_map_ = false;
     }
 
     if (!has_goal_ || !has_start_)

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -920,7 +920,7 @@ protected:
 
     if (clear_hysteresis && has_hysteresis_map_)
     {
-      ROS_INFO("Previous path may cause collision to the obstacle. Clearing hysteresis map.");
+      ROS_INFO("The previous path collides to the obstacle. Clearing hysteresis map.");
       cm_hyst_.clear(100);
       has_hysteresis_map_ = false;
     }

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -759,7 +759,7 @@ protected:
 
               point.z = 100;
               for (p[2] = 0; p[2] < static_cast<int>(map_info_.angle); ++p[2])
-                point.z = std::min(static_cast<float>(std::max(0, static_cast<int>(cm_hyst_[p]))), point.z);
+                point.z = std::min(static_cast<float>(cm_hyst_[p]), point.z);
 
               point.z *= 0.01;
               break;
@@ -864,7 +864,7 @@ protected:
             const char c = msg->data[addr];
             if (c < cost_min)
               cost_min = c;
-            if (c == 100 && !clear_hysteresis && cm_hyst_[gp + p] == -1)
+            if (c == 100 && !clear_hysteresis && cm_hyst_[gp + p] == 0)
               clear_hysteresis = true;
           }
           p[2] = 0;
@@ -916,7 +916,7 @@ protected:
 
     if (clear_hysteresis)
     {
-      ROS_INFO("Previous path may cause collision to the obstacle. Clearing hysteresis map.");
+      ROS_DEBUG("Previous path may make collision to the obstacle. Clearing hysteresis map.");
       cm_hyst_.clear(100);
     }
 
@@ -1762,15 +1762,8 @@ protected:
           }
           it_prev = it;
         }
-        if (d_min < 1.0)
-        {
-          cm_hyst_[p] = -1;
-        }
-        else
-        {
-          d_min = std::max(expand_dist, std::min(expand_dist + max_dist, d_min));
-          cm_hyst_[p] = lroundf((d_min - expand_dist) * 100.0 / max_dist);
-        }
+        d_min = std::max(expand_dist, std::min(expand_dist + max_dist, d_min));
+        cm_hyst_[p] = lroundf((d_min - expand_dist) * 100.0 / max_dist);
       }
       const auto tnow = boost::chrono::high_resolution_clock::now();
       ROS_DEBUG("Hysteresis map generated (%0.4f sec.)",
@@ -1948,7 +1941,7 @@ protected:
         sum += c;
 
         if (hyst)
-          sum_hyst += std::max(0, static_cast<int>(cm_hyst_[pos]));
+          sum_hyst += cm_hyst_[pos];
       }
       const float distf = cache_page->second.getDistance();
       cost += sum * map_info_.linear_resolution * distf * cc_.weight_costmap_ / (100.0 * num);
@@ -2010,7 +2003,7 @@ protected:
           sum += c;
 
           if (hyst)
-            sum_hyst += std::max(0, static_cast<int>(cm_hyst_[pos]));
+            sum_hyst += cm_hyst_[pos];
         }
         const float distf = cache_page->second.getDistance();
         cost += sum * map_info_.linear_resolution * distf * cc_.weight_costmap_ / (100.0 * num);

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -916,7 +916,7 @@ protected:
 
     if (clear_hysteresis)
     {
-      ROS_DEBUG("Previous path may make collision to the obstacle. Clearing hysteresis map.");
+      ROS_INFO("Previous path may cause collision to the obstacle. Clearing hysteresis map.");
       cm_hyst_.clear(100);
     }
 

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1752,10 +1752,13 @@ protected:
         {
           if (it != it_prev)
           {
-            const float d =
-                CyclicVecFloat<3, 2>(p).distLinestrip2d(*it_prev, *it);
-            if (d < d_min)
-              d_min = d;
+            if (lroundf((*it)[2]) == p[2] || lroundf((*it_prev)[2]) == p[2])
+            {
+              const float d =
+                  CyclicVecFloat<3, 2>(p).distLinestrip2d(*it_prev, *it);
+              if (d < d_min)
+                d_min = d;
+            }
           }
           it_prev = it;
         }


### PR DESCRIPTION
fix #311

- speed-up replanning against moving obstacle
- avoid to generate a path close to the moving obstacle