### PR TITLE
trajectory_tracker: track interpolated rotation

### DIFF
--- a/trajectory_tracker/include/trajectory_tracker/path2d.h
+++ b/trajectory_tracker/include/trajectory_tracker/path2d.h
@@ -95,9 +95,12 @@ public:
     ConstIterator it_prev = begin;
     for (ConstIterator it = begin + 1; it < end; ++it)
     {
+      // stop reading forward if the path is switching back or in-place turning
+      if (it->pos_ == it_prev->pos_)
+        return it;
+
       const Eigen::Vector2d inc = it->pos_ - it_prev->pos_;
 
-      // stop reading forward if the path is switching back
       const float angle = atan2(inc[1], inc[0]);
       const float angle_pose = allow_backward_motion ? it->yaw_ : angle;
       const float sign_vel_req = std::cos(angle) * std::cos(angle_pose) + std::sin(angle) * std::sin(angle_pose);
@@ -115,8 +118,8 @@ public:
       const float max_search_range = 0) const
   {
     float distance_path_search = 0;
-    float min_dist = std::numeric_limits<float>::max();
-    ConstIterator it_nearest = Super::end();
+    ConstIterator it_nearest = begin;
+    float min_dist = (begin->pos_ - target).norm();
 
     ConstIterator it_prev = begin;
     for (ConstIterator it = begin + 1; it < end; ++it)

--- a/trajectory_tracker/src/trajectory_tracker.cpp
+++ b/trajectory_tracker/src/trajectory_tracker.cpp
@@ -511,9 +511,10 @@ void TrackerNode::control()
   tracking.pose.orientation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0.0, 0.0, 1.0), -angle));
   pub_tracking_.publish(tracking);
 
-  path_step_done_ = i_nearest > 0 ? std::max(path_step_done_, i_nearest - 1) : 0;
   if (arrive_local_goal)
     path_step_done_ = i_local_goal;
+  else
+    path_step_done_ = std::max(path_step_done_, i_nearest - 1);
 }
 
 int main(int argc, char** argv)

--- a/trajectory_tracker/src/trajectory_tracker.cpp
+++ b/trajectory_tracker/src/trajectory_tracker.cpp
@@ -512,7 +512,8 @@ void TrackerNode::control()
   pub_vel_.publish(cmd_vel);
   status.status = trajectory_tracker_msgs::TrajectoryTrackerStatus::FOLLOWING;
   if (std::abs(status.distance_remains) < goal_tolerance_dist_ &&
-      std::abs(status.angle_remains) < goal_tolerance_ang_)
+      std::abs(status.angle_remains) < goal_tolerance_ang_ &&
+      it_local_goal == lpath.end())
   {
     status.status = trajectory_tracker_msgs::TrajectoryTrackerStatus::GOAL;
   }

--- a/trajectory_tracker/src/trajectory_tracker.cpp
+++ b/trajectory_tracker/src/trajectory_tracker.cpp
@@ -526,11 +526,9 @@ void TrackerNode::control()
   tracking.pose.orientation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0.0, 0.0, 1.0), -angle));
   pub_tracking_.publish(tracking);
 
-  path_step_done_ = i_nearest - 1;  // i_nearest is the next of the nearest node
-  if (path_step_done_ < 0)
-    path_step_done_ = 0;
+  path_step_done_ = i_nearest > 0 ? std::max(path_step_done_, i_nearest - 1) : 0;
   if (arrive_local_goal)
-    path_step_done_ = i_local_goal + 1;
+    path_step_done_ = i_local_goal;
 }
 
 int main(int argc, char** argv)

--- a/trajectory_tracker/src/trajectory_tracker.cpp
+++ b/trajectory_tracker/src/trajectory_tracker.cpp
@@ -237,6 +237,8 @@ void TrackerNode::cbPath(const typename MSG_TYPE::ConstPtr& msg)
 
     if ((path_.back().pos_ - next.pos_).squaredNorm() >= std::pow(epsilon_, 2))
       path_.push_back(next);
+    else
+      path_.back() = next;
   }
 
   if (path_.size() == 1)


### PR DESCRIPTION
Paths end with interpolated rotation were not correctly tracked.
e.g. tracking a following path stopped before reaching final pose.

- x: 0, y: 0, yaw: 0
- x: 1, y: 0, yaw: 0
- x: 2, y: 0, yaw: 0 (stopped here)
- x: 2, y: 0, yaw: 1
- x: 2, y: 0, yaw: 2
- x: 2, y: 0, yaw: 3

