### PR TITLE
planner_cspace: implement motion primitive algorithm for speed-up

### DIFF
--- a/planner_cspace/CMakeLists.txt
+++ b/planner_cspace/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(planner_3d
   src/costmap_bbf.cpp
   src/grid_astar_model_3dof.cpp
   src/motion_cache.cpp
+  src/motion_primitive_builder.cpp
   src/path_interpolator.cpp
   src/planner_3d.cpp
   src/rotation_cache.cpp

--- a/planner_cspace/include/planner_cspace/planner_3d/grid_astar_model.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/grid_astar_model.h
@@ -35,12 +35,12 @@
 
 #include <costmap_cspace_msgs/MapMetaData3D.h>
 
-#include <planner_cspace/cyclic_vec.h>
-#include <planner_cspace/planner_3d/motion_cache.h>
-#include <planner_cspace/planner_3d/rotation_cache.h>
-#include <planner_cspace/planner_3d/path_interpolator.h>
-#include <planner_cspace/grid_astar_model.h>
 #include <planner_cspace/blockmem_gridmap.h>
+#include <planner_cspace/cyclic_vec.h>
+#include <planner_cspace/grid_astar_model.h>
+#include <planner_cspace/planner_3d/motion_cache.h>
+#include <planner_cspace/planner_3d/path_interpolator.h>
+#include <planner_cspace/planner_3d/rotation_cache.h>
 
 namespace planner_cspace
 {
@@ -81,7 +81,7 @@ protected:
   costmap_cspace_msgs::MapMetaData3D map_info_;
   Vecf euclid_cost_coef_;
   Vecf resolution_;
-  std::vector<Vec> search_list_;
+  std::vector<std::vector<Vec>> motion_primitives_;
   std::vector<Vec> search_list_rough_;
   int local_range_;
   BlockMemGridmapBase<float, 3, 2>& cost_estim_cache_;

--- a/planner_cspace/include/planner_cspace/planner_3d/motion_primitive_builder.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/motion_primitive_builder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019, the neonavigation authors
+ * Copyright (c) 2020, the neonavigation authors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/planner_cspace/include/planner_cspace/planner_3d/motion_primitive_builder.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/motion_primitive_builder.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018-2019, the neonavigation authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLANNER_CSPACE_PLANNER_3D_MOTION_PRIMITIVE_BUILDER_H
+#define PLANNER_CSPACE_PLANNER_3D_MOTION_PRIMITIVE_BUILDER_H
+
+#include <vector>
+
+#include <costmap_cspace_msgs/MapMetaData3D.h>
+#include <planner_cspace/cyclic_vec.h>
+#include <planner_cspace/planner_3d/grid_astar_model.h>
+
+namespace planner_cspace
+{
+namespace planner_3d
+{
+class MotionPrimitiveBuilder
+{
+public:
+  using Vec = CyclicVecInt<3, 2>;
+  using Vecf = CyclicVecFloat<3, 2>;
+
+  static std::vector<std::vector<Vec>> build(const costmap_cspace_msgs::MapMetaData3D& map_info,
+                                             const CostCoeff& cc, const int range);
+
+private:
+};
+}  // namespace planner_3d
+}  // namespace planner_cspace
+
+#endif  // PLANNER_CSPACE_PLANNER_3D_MOTION_PRIMITIVE_BUILDER_H

--- a/planner_cspace/src/grid_astar_model_3dof.cpp
+++ b/planner_cspace/src/grid_astar_model_3dof.cpp
@@ -39,6 +39,7 @@
 #include <planner_cspace/cyclic_vec.h>
 #include <planner_cspace/planner_3d/grid_astar_model.h>
 #include <planner_cspace/planner_3d/motion_cache.h>
+#include <planner_cspace/planner_3d/motion_primitive_builder.h>
 #include <planner_cspace/planner_3d/path_interpolator.h>
 #include <planner_cspace/planner_3d/rotation_cache.h>
 
@@ -98,21 +99,9 @@ GridAstarModel3D::GridAstarModel3D(
 
   createEuclidCostCache();
 
-  Vec d;
-  search_list_.clear();
-  for (d[0] = -range_; d[0] <= range_; d[0]++)
-  {
-    for (d[1] = -range_; d[1] <= range_; d[1]++)
-    {
-      if (d.sqlen() > range_ * range_)
-        continue;
-      for (d[2] = 0; d[2] < static_cast<int>(map_info_.angle); d[2]++)
-      {
-        search_list_.push_back(d);
-      }
-    }
-  }
+  motion_primitives_ = MotionPrimitiveBuilder::build(map_info_, cc_, range_);
   search_list_rough_.clear();
+  Vec d;
   for (d[0] = -range_; d[0] <= range_; d[0]++)
   {
     for (d[1] = -range_; d[1] <= range_; d[1]++)
@@ -197,21 +186,6 @@ float GridAstarModel3D::cost(
 
   const Vec d2(d[0] + range_, d[1] + range_, next[2]);
   const Vecf motion = rot_cache_.getMotion(cur[2], d2);
-  const Vecf motion_grid = motion * resolution_;
-
-  if (std::lround(motion_grid[0]) == 0 && std::lround(motion_grid[1]) != 0)
-  {
-    // Not non-holonomic
-    return -1;
-  }
-
-  if (std::abs(motion[2]) >= 2.0 * M_PI / 4.0)
-  {
-    // Over 90 degree turn
-    // must be separated into two curves
-    return -1;
-  }
-
   const float dist = motion.len();
 
   if (motion[0] < 0)
@@ -222,12 +196,7 @@ float GridAstarModel3D::cost(
 
   if (d[2] == 0)
   {
-    if (std::lround(motion_grid[0]) == 0)
-      return -1;  // side slip
     const float aspect = motion[0] / motion[1];
-    if (std::abs(aspect) < cc_.angle_resolution_aspect_)
-      return -1;  // large y offset
-
     cost += euclid_cost_coef_[2] * std::abs(1.0 / aspect) * map_info_.angular_resolution / (M_PI * 2.0);
 
     // Go-straight
@@ -257,27 +226,10 @@ float GridAstarModel3D::cost(
   }
   else
   {
-    // Curve
-    if (motion[0] * motion[1] * motion[2] < 0)
-      return -1;
-
-    if (d.sqlen() < 3 * 3)
-      return -1;
-
     const std::pair<float, float>& radiuses = rot_cache_.getRadiuses(cur[2], d2);
     const float r1 = radiuses.first;
     const float r2 = radiuses.second;
-
-    // curveture at the start_ pose and the end pose must be same
-    if (std::abs(r1 - r2) >= map_info_.linear_resolution * 1.5)
-    {
-      // Drifted
-      return -1;
-    }
-
     const float curv_radius = (r1 + r2) / 2;
-    if (std::abs(curv_radius) < cc_.min_curve_raduis_)
-      return -1;
 
     // Ignore boundary
     if (cur[0] < min_boundary_[0] || cur[1] < min_boundary_[1] ||
@@ -287,7 +239,6 @@ float GridAstarModel3D::cost(
     if (std::abs(cc_.max_vel_ / r1) > cc_.max_ang_vel_)
     {
       const float vel = std::abs(curv_radius) * cc_.max_ang_vel_;
-
       // Curve deceleration penalty
       cost += dist * std::abs(vel / cc_.max_vel_) * cc_.weight_decel_;
     }
@@ -352,7 +303,8 @@ const std::vector<GridAstarModel3D::Vec>& GridAstarModel3D::searchGrids(
 
     if (ds.sqlen() < local_range_sq)
     {
-      return search_list_;
+      //      return search_list_;
+      return motion_primitives_[p[2]];
     }
   }
   return search_list_rough_;

--- a/planner_cspace/src/grid_astar_model_3dof.cpp
+++ b/planner_cspace/src/grid_astar_model_3dof.cpp
@@ -303,7 +303,6 @@ const std::vector<GridAstarModel3D::Vec>& GridAstarModel3D::searchGrids(
 
     if (ds.sqlen() < local_range_sq)
     {
-      //      return search_list_;
       return motion_primitives_[p[2]];
     }
   }

--- a/planner_cspace/src/motion_primitive_builder.cpp
+++ b/planner_cspace/src/motion_primitive_builder.cpp
@@ -69,7 +69,7 @@ std::vector<std::vector<MotionPrimitiveBuilder::Vec>> MotionPrimitiveBuilder::bu
   }
 
   motion_primitives.resize(map_info.angle);
-  for (size_t i = 0; i < motion_primitives.size(); ++i)
+  for (int i = 0; i < static_cast<int>(motion_primitives.size()); ++i)
   {
     auto& current_primitives = motion_primitives[i];
     for (const auto& prim : search_list)
@@ -85,7 +85,7 @@ std::vector<std::vector<MotionPrimitiveBuilder::Vec>> MotionPrimitiveBuilder::bu
         continue;
       }
       int next_angle = i + prim[2];
-      if (next_angle >= map_info.angle)
+      if (next_angle >= static_cast<int>(map_info.angle))
       {
         next_angle -= map_info.angle;
       }

--- a/planner_cspace/src/motion_primitive_builder.cpp
+++ b/planner_cspace/src/motion_primitive_builder.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2020, the neonavigation authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <planner_cspace/planner_3d/motion_primitive_builder.h>
+
+#include <utility>
+#include <vector>
+
+#include <costmap_cspace_msgs/MapMetaData3D.h>
+#include <planner_cspace/cyclic_vec.h>
+#include <planner_cspace/planner_3d/grid_astar_model.h>
+#include <planner_cspace/planner_3d/rotation_cache.h>
+
+namespace planner_cspace
+{
+namespace planner_3d
+{
+std::vector<std::vector<MotionPrimitiveBuilder::Vec>> MotionPrimitiveBuilder::build(
+    const costmap_cspace_msgs::MapMetaData3D& map_info, const CostCoeff& cc, const int range)
+{
+  RotationCache rot_cache;
+  rot_cache.reset(map_info.linear_resolution, map_info.angular_resolution, range);
+  Vecf resolution_(1.0f / map_info.linear_resolution,
+                   1.0f / map_info.linear_resolution,
+                   1.0f / map_info.angular_resolution);
+
+  std::vector<std::vector<Vec>> motion_primitives;
+  std::vector<Vec> search_list;
+  {
+    Vec d;
+    for (d[0] = -range; d[0] <= range; d[0]++)
+    {
+      for (d[1] = -range; d[1] <= range; d[1]++)
+      {
+        if (d.sqlen() > range * range)
+          continue;
+        for (d[2] = 0; d[2] < static_cast<int>(map_info.angle); d[2]++)
+        {
+          search_list.push_back(d);
+        }
+      }
+    }
+  }
+
+  motion_primitives.resize(map_info.angle);
+  for (size_t i = 0; i < motion_primitives.size(); ++i)
+  {
+    auto& current_primitives = motion_primitives[i];
+    for (const auto& prim : search_list)
+    {
+      if (prim[0] == 0 && prim[1] == 0)
+      {
+        if (prim[2] == 0)
+        {
+          continue;
+        }
+        // Rotation
+        current_primitives.push_back(prim);
+        continue;
+      }
+      int next_angle = i + prim[2];
+      if (next_angle >= map_info.angle)
+      {
+        next_angle -= map_info.angle;
+      }
+      const Vec d2(prim[0] + range, prim[1] + range, next_angle);
+      const Vecf motion = rot_cache.getMotion(i, d2);
+      const Vecf motion_grid = motion * resolution_;
+
+      if (std::lround(motion_grid[0]) == 0 && std::lround(motion_grid[1]) != 0)
+      {
+        // Not non-holonomic
+        continue;
+      }
+
+      static constexpr float EPS = 1.0e-6f;
+      if (std::abs(motion[2]) >= 2.0 * M_PI / 4.0 - EPS)
+      {
+        // Over 90 degree turn
+        // must be separated into two curves
+        continue;
+      }
+
+      if (prim[2] == 0)
+      {
+        // Straight
+        if (std::lround(motion_grid[0]) == 0)
+        {
+          // side slip
+          continue;
+        }
+        const float aspect = motion[0] / motion[1];
+        if (std::abs(aspect) < cc.angle_resolution_aspect_)
+        {
+          // large y offset
+          continue;
+        }
+        current_primitives.push_back(prim);
+      }
+      else
+      {
+        // Curve
+        if (std::abs(motion[1]) < map_info.linear_resolution / 2.0)
+        {
+          // No y direction movement
+          continue;
+        }
+        if (motion[0] * motion[1] * motion[2] < 0)
+        {
+          continue;
+        }
+        if (prim.sqlen() < 3 * 3)
+        {
+          continue;
+        }
+        const std::pair<float, float>& radiuses = rot_cache.getRadiuses(i, d2);
+        const float r1 = radiuses.first;
+        const float r2 = radiuses.second;
+        if (std::abs(r1 - r2) >= map_info.linear_resolution * 1.5)
+        {
+          // Drifted
+          continue;
+        }
+        const float curv_radius = (r1 + r2) / 2;
+        if (std::abs(curv_radius) < cc.min_curve_raduis_)
+        {
+          continue;
+        }
+        current_primitives.push_back(prim);
+      }
+    }
+  }
+
+  return motion_primitives;
+}
+}  // namespace planner_3d
+}  // namespace planner_cspace

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -972,6 +972,7 @@ protected:
       tolerance_angle_ = std::lround(tolerance_angle_f_ / map_info_.angular_resolution);
       goal_tolerance_lin_ = std::lround(goal_tolerance_lin_f_ / map_info_.linear_resolution);
       goal_tolerance_ang_ = std::lround(goal_tolerance_ang_f_ / map_info_.angular_resolution);
+      cc_.angle_resolution_aspect_ = 2.0 / tanf(map_info_.angular_resolution);
 
       model_.reset(
           new GridAstarModel3D(
@@ -1522,7 +1523,6 @@ protected:
     pub_start_.publish(p);
 
     const float range_limit = cost_estim_cache_[s_rough] - (local_range_ + range_) * ec_[0];
-    cc_.angle_resolution_aspect_ = 2.0 / tanf(map_info_.angular_resolution);
 
     const auto ts = boost::chrono::high_resolution_clock::now();
     // ROS_INFO("Planning from (%d, %d, %d) to (%d, %d, %d)",

--- a/planner_cspace/test/CMakeLists.txt
+++ b/planner_cspace/test/CMakeLists.txt
@@ -14,6 +14,7 @@ catkin_add_gtest(test_planner_3d_cost
   src/test_planner_3d_cost.cpp
   ../src/grid_astar_model_3dof.cpp
   ../src/motion_cache.cpp
+  ../src/motion_primitive_builder.cpp
   ../src/rotation_cache.cpp
 )
 target_link_libraries(test_planner_3d_cost ${catkin_LIBRARIES} ${Boost_LIBRARIES})
@@ -29,6 +30,13 @@ catkin_add_gtest(test_motion_cache
   ../src/motion_cache.cpp
 )
 target_link_libraries(test_motion_cache ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+catkin_add_gtest(test_motion_primitive_builder
+  src/test_motion_primitive_builder.cpp
+  ../src/motion_primitive_builder.cpp
+  ../src/rotation_cache.cpp
+)
+target_link_libraries(test_motion_primitive_builder ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_rostest_gtest(test_debug_outputs
   test/debug_outputs_rostest.test

--- a/planner_cspace/test/src/test_motion_primitive_builder.cpp
+++ b/planner_cspace/test/src/test_motion_primitive_builder.cpp
@@ -268,7 +268,7 @@ TEST(MotionPrimitiveBuilder, Generate)
   const std::vector<std::vector<MotionPrimitiveBuilder::Vec>> motion_primitives =
       MotionPrimitiveBuilder::build(map_info, cc, range);
 
-  EXPECT_EQ(map_info.angle, static_cast<int>(motion_primitives.size()));
+  EXPECT_EQ(map_info.angle, static_cast<unsigned int>(motion_primitives.size()));
   for (size_t i = 0; i < motion_primitives.size(); ++i)
   {
     std::vector<Vec> current_primitives = motion_primitives[i];

--- a/planner_cspace/test/src/test_motion_primitive_builder.cpp
+++ b/planner_cspace/test/src/test_motion_primitive_builder.cpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2020, the neonavigation authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+#include <vector>
+
+#include <planner_cspace/cyclic_vec.h>
+#include <planner_cspace/planner_3d/motion_primitive_builder.h>
+
+#include <gtest/gtest.h>
+
+namespace planner_cspace
+{
+namespace planner_3d
+{
+using Vec = MotionPrimitiveBuilder::Vec;
+
+bool compareVecs(const Vec& v1, const Vec& v2)
+{
+  if (v1[0] != v2[0])
+    return v1[0] < v2[0];
+  if (v1[1] != v2[1])
+    return v1[1] < v2[1];
+  return v1[2] < v2[2];
+}
+
+std::vector<Vec> buildExpectedPrimitives(const std::vector<std::vector<Vec>> original_primitives_vector,
+                                         const int quadrant)
+{
+  std::vector<Vec> results;
+  for (const auto& original_primitives : original_primitives_vector)
+  {
+    for (const auto& original_primitive : original_primitives)
+    {
+      Vec primitive;
+      switch (quadrant)
+      {
+        case 0:
+          primitive = original_primitive;
+          break;
+        case 1:
+          primitive = Vec(original_primitive[1], -original_primitive[0], original_primitive[2]);
+          primitive.cycleUnsigned(16);
+          break;
+        case 2:
+          primitive = Vec(-original_primitive[0], -original_primitive[1], original_primitive[2]);
+          primitive.cycleUnsigned(16);
+          break;
+        case 3:
+          primitive = Vec(-original_primitive[1], original_primitive[0], original_primitive[2]);
+          primitive.cycleUnsigned(16);
+          break;
+        default:
+          break;
+      }
+      results.push_back(primitive);
+      const Vec opposite = Vec(-primitive[0], -primitive[1], primitive[2]);
+      results.push_back(opposite);
+    }
+  }
+  // In-place turns
+  for (int i = 1; i < 16; ++i)
+  {
+    results.push_back(Vec(0, 0, i));
+  }
+  std::sort(results.begin(), results.end(), &compareVecs);
+  return results;
+}
+
+TEST(MotionPrimitiveBuilder, Generate)
+{
+  // clang-format off
+  const std::vector<Vec> expected_0deg_straight_primitives =
+  {
+      Vec(1, 0, 0),
+      Vec(2, 0, 0),
+      Vec(3, 0, 0),
+      Vec(4, 0, 0),
+  };
+  const std::vector<Vec> expected_0deg_rotation_1_primitives =
+  {
+      Vec(3, -2, 15),
+      Vec(3, -1, 15),
+      Vec(3,  1,  1),
+      Vec(3,  2,  1),
+  };
+  const std::vector<Vec> expected_0deg_rotation_2_primitives =
+  {
+      Vec(3, -2, 14),
+      Vec(3, -1, 14),
+      Vec(3,  1,  2),
+      Vec(3,  2,  2),
+  };
+  const std::vector<Vec> expected_0deg_rotation_3_primitives =
+  {
+      Vec(3, -2, 13),
+      Vec(3, -1, 13),
+      Vec(3,  1,  3),
+      Vec(3,  2,  3),
+  };
+  const std::vector<std::vector<Vec>> expected_0deg_primitives =
+  {
+    expected_0deg_straight_primitives,
+    expected_0deg_rotation_1_primitives,
+    expected_0deg_rotation_2_primitives,
+    expected_0deg_rotation_3_primitives,
+  };
+
+  const std::vector<Vec> expected_23deg_straight_primitives =
+  {
+      Vec(2, 1, 0),
+      Vec(3, 1, 0),
+      Vec(3, 2, 0),
+  };
+  const std::vector<Vec> expected_23deg_rotation_1_primitives =
+  {
+      Vec(2, 3,  1),
+      Vec(3, 0, 15),
+      Vec(3, 2,  1),
+      Vec(4, 0, 15),
+  };
+  const std::vector<Vec> expected_23deg_rotation_2_primitives =
+  {
+      Vec(2,  3,  2),
+      Vec(3,  2,  2),
+      Vec(3, -1, 14),
+      Vec(3,  0, 14),
+      Vec(4,  0, 14),
+  };
+  const std::vector<Vec> expected_23deg_rotation_3_primitives =
+  {
+      Vec(1,  3,  3),
+      Vec(2,  3,  3),
+      Vec(3, -1, 13),
+      Vec(3,  0, 13),
+      Vec(4,  0, 13),
+  };
+  const std::vector<std::vector<Vec>> expected_23deg_primitives =
+  {
+    expected_23deg_straight_primitives,
+    expected_23deg_rotation_1_primitives,
+    expected_23deg_rotation_2_primitives,
+    expected_23deg_rotation_3_primitives,
+  };
+
+  const std::vector<Vec> expected_45deg_straight_primitives =
+  {
+      Vec(1, 1, 0),
+      Vec(2, 2, 0),
+      Vec(3, 2, 0),
+      Vec(2, 3, 0),
+  };
+  const std::vector<Vec> expected_45deg_rotation_1_primitives =
+  {
+      Vec(1, 3,  1),
+      Vec(2, 3,  1),
+      Vec(3, 1, 15),
+      Vec(3, 2, 15),
+  };
+  const std::vector<Vec> expected_45deg_rotation_2_primitives =
+  {
+      Vec(0, 3,  2),
+      Vec(1, 3,  2),
+      Vec(2, 3,  2),
+      Vec(3, 0, 14),
+      Vec(3, 1, 14),
+      Vec(3, 2, 14),
+  };
+  const std::vector<Vec> expected_45deg_rotation_3_primitives =
+  {
+      Vec(0, 3,  3),
+      Vec(0, 4,  3),
+      Vec(1, 3,  3),
+      Vec(3, 0, 13),
+      Vec(3, 1, 13),
+      Vec(4, 0, 13),
+  };
+  const std::vector<std::vector<Vec>> expected_45deg_primitives =
+  {
+    expected_45deg_straight_primitives,
+    expected_45deg_rotation_1_primitives,
+    expected_45deg_rotation_2_primitives,
+    expected_45deg_rotation_3_primitives,
+  };
+
+  const std::vector<Vec> expected_67deg_straight_primitives =
+  {
+      Vec(1, 2, 0),
+      Vec(1, 3, 0),
+      Vec(2, 3, 0),
+  };
+  const std::vector<Vec> expected_67deg_rotation_1_primitives =
+  {
+      Vec(0, 3,  1),
+      Vec(0, 4,  1),
+      Vec(2, 3, 15),
+      Vec(3, 2, 15),
+  };
+  const std::vector<Vec> expected_67deg_rotation_2_primitives =
+  {
+      Vec(0, 3,  2),
+      Vec(0, 4,  2),
+      Vec(-1, 3,  2),
+      Vec(2, 3, 14),
+      Vec(3, 2, 14),
+  };
+  const std::vector<Vec> expected_67deg_rotation_3_primitives =
+  {
+      Vec(0,  3,  3),
+      Vec(0,  4,  3),
+      Vec(1, -3,  3),
+      Vec(3,  1, 13),
+      Vec(3,  2, 13),
+  };
+  const std::vector<std::vector<Vec>> expected_67deg_primitives =
+  {
+    expected_67deg_straight_primitives,
+    expected_67deg_rotation_1_primitives,
+    expected_67deg_rotation_2_primitives,
+    expected_67deg_rotation_3_primitives,
+  };
+
+  const std::vector<std::vector<std::vector<Vec>>> expected_original_primitives =
+  {
+    expected_0deg_primitives,
+    expected_23deg_primitives,
+    expected_45deg_primitives,
+    expected_67deg_primitives,
+  };
+  // clang-format on
+
+  costmap_cspace_msgs::MapMetaData3D map_info;
+  map_info.linear_resolution = 0.1f;
+  map_info.angular_resolution = static_cast<float>(M_PI / 8);
+  map_info.angle = 16;
+
+  CostCoeff cc;
+  cc.min_curve_raduis_ = 0.1f;
+  cc.angle_resolution_aspect_ = 2.0f / tanf(map_info.angular_resolution);
+
+  const int range = 4;
+  const std::vector<std::vector<MotionPrimitiveBuilder::Vec>> motion_primitives =
+      MotionPrimitiveBuilder::build(map_info, cc, range);
+
+  EXPECT_EQ(map_info.angle, static_cast<int>(motion_primitives.size()));
+  for (size_t i = 0; i < motion_primitives.size(); ++i)
+  {
+    std::vector<Vec> current_primitives = motion_primitives[i];
+    std::sort(current_primitives.begin(), current_primitives.end(), &compareVecs);
+    const auto expected_primitives = buildExpectedPrimitives(expected_original_primitives[i % 4], i / 4);
+    ASSERT_EQ(expected_primitives.size(), current_primitives.size());
+    for (size_t j = 0; j < current_primitives.size(); ++j)
+    {
+      const Vec& expected_prim = expected_primitives[j];
+      const Vec& actual_prim = current_primitives[j];
+
+      EXPECT_EQ(expected_prim, actual_prim)
+          << "Error at " << i << "," << j << "\n"
+          << " Expected: (" << expected_prim[0] << "," << expected_prim[1] << "," << expected_prim[2] << ")\n"
+          << " Actual: (" << actual_prim[0] << "," << actual_prim[1] << "," << actual_prim[2] << ")\n";
+    }
+  }
+}
+
+}  // namespace planner_3d
+}  // namespace planner_cspace
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/planner_cspace/test/src/test_planner_3d_cost.cpp
+++ b/planner_cspace/test/src/test_planner_3d_cost.cpp
@@ -87,12 +87,10 @@ TEST(GridAstarModel3D, Cost)
   const float c_curve = model.cost(start, goal_curve, starts, goal_curve);
   const float c_drift = model.cost(start, goal_drift, starts, goal_drift);
   const float c_drift_curve = model.cost(start, goal_curve_drift, starts, goal_curve_drift);
-  const float c_curve_sign_err = model.cost(start, goal_curve_sign_err, starts, goal_curve_sign_err);
 
   EXPECT_LT(c_straight, c_curve);
   EXPECT_LT(c_straight, c_drift);
   EXPECT_LT(c_straight, c_drift_curve);
-  EXPECT_EQ(-1, c_curve_sign_err);
 }
 }  // namespace planner_3d
 }  // namespace planner_cspace


### PR DESCRIPTION
Instead of whole search_list, only followable moving primitives are remained in A* algorithm.
This PR can reduce calculation time significantly.

The following performance comparisons are performed using our simulator.
Times are obtained from messages shown by L1547 of planner_3d.cpp.

Average time while 3-dof planning: 
master: 0.3514 sec.
This PR: 0.0520 sec.
Worst time: 
master: 0.9421 sec.
This PR: 0.1582 sec.