### PR TITLE
trajectory_tracker: calculate correct curvature at the end of path

### DIFF
--- a/trajectory_tracker/include/trajectory_tracker/path2d.h
+++ b/trajectory_tracker/include/trajectory_tracker/path2d.h
@@ -69,6 +69,21 @@ public:
     , velocity_(velocity)
   {
   }
+  inline void rotate(const float ang)
+  {
+    const float org_x = pos_.x();
+    const float org_y = pos_.y();
+    const float cos_v = cosf(ang);
+    const float sin_v = sinf(ang);
+
+    pos_.x() = cos_v * org_x - sin_v * org_y;
+    pos_.y() = sin_v * org_x + cos_v * org_y;
+    yaw_ += ang;
+    while (yaw_ < 0)
+      yaw_ += 2 * M_PI;
+    while (yaw_ > 2 * M_PI)
+      yaw_ -= 2 * M_PI;
+  }
 };
 class Path2D : public std::vector<Pose2D>
 {
@@ -174,7 +189,7 @@ public:
     }
     return remain;
   }
-  inline float getCurvature(
+  inline float getCurvatureWith3Points(
       const ConstIterator& begin,
       const ConstIterator& end,
       const Eigen::Vector2d& target_on_line,
@@ -191,6 +206,33 @@ public:
         break;
       it_prev2 = it_prev1;
       it_prev1 = it;
+    }
+    return curv;
+  }
+  inline float getCurvatureWith2Poses(
+      const ConstIterator& begin,
+      const ConstIterator& end,
+      const Eigen::Vector2d& target_on_line,
+      const float max_search_range) const
+  {
+    const float max_search_range_sq = max_search_range * max_search_range;
+    trajectory_tracker::Average<float> curv;
+    ConstIterator it_prev = begin;
+    for (ConstIterator it = begin + 1; it < end; ++it)
+    {
+      Pose2D rel(it->pos_ - it_prev->pos_, it->yaw_, 0.0f);
+      rel.rotate(-it_prev->yaw_);
+
+      const float sin_v = std::sin(rel.yaw_);
+      const float cos_v = std::cos(rel.yaw_);
+      const float r1 = rel.pos_.y() + rel.pos_.x() * cos_v / sin_v;
+      const float r2 = std::copysign(
+          std::sqrt(std::pow(rel.pos_.x(), 2) + std::pow(rel.pos_.x() * cos_v / sin_v, 2)),
+          rel.pos_.x() * sin_v);
+      curv += 1.0f / ((r1 + r2) / 2);
+      if ((it->pos_ - target_on_line).squaredNorm() > max_search_range_sq)
+        break;
+      it_prev = it;
     }
     return curv;
   }

--- a/trajectory_tracker/include/trajectory_tracker/path2d.h
+++ b/trajectory_tracker/include/trajectory_tracker/path2d.h
@@ -73,8 +73,8 @@ public:
   {
     const float org_x = pos_.x();
     const float org_y = pos_.y();
-    const float cos_v = cosf(ang);
-    const float sin_v = sinf(ang);
+    const float cos_v = std::cos(ang);
+    const float sin_v = std::sin(ang);
 
     pos_.x() = cos_v * org_x - sin_v * org_y;
     pos_.y() = sin_v * org_x + cos_v * org_y;

--- a/trajectory_tracker/include/trajectory_tracker/path2d.h
+++ b/trajectory_tracker/include/trajectory_tracker/path2d.h
@@ -207,7 +207,7 @@ public:
       Pose2D rel(it->pos_ - it_prev->pos_, it->yaw_, 0.0f);
       rel.rotate(-it_prev->yaw_);
       const float sin_v = std::sin(rel.yaw_);
-      const static float EPS = 1.0e-6;
+      static const float EPS = 1.0e-6f;
       if (std::abs(sin_v) < EPS)
       {
         return 0;

--- a/trajectory_tracker/src/trajectory_tracker.cpp
+++ b/trajectory_tracker/src/trajectory_tracker.cpp
@@ -390,8 +390,8 @@ void TrackerNode::control()
 
   // Curvature
   const float curv = calc_curvature_with_2_poses_ ?
-                         lpath.getCurvatureWith3Points(it_nearest, it_local_goal, pos_on_line, curv_forward_) :
-                         lpath.getCurvatureWith2Poses(it_nearest, it_local_goal, pos_on_line, curv_forward_);
+                         lpath.getCurvatureWith2Poses(it_nearest, it_local_goal, pos_on_line, curv_forward_) :
+                         lpath.getCurvatureWith3Points(it_nearest, it_local_goal, pos_on_line, curv_forward_);
 
   status.distance_remains = remain;
   status.angle_remains = angle;

--- a/trajectory_tracker/src/trajectory_tracker.cpp
+++ b/trajectory_tracker/src/trajectory_tracker.cpp
@@ -107,7 +107,6 @@ private:
   bool limit_vel_by_avel_;
   bool check_old_path_;
   double epsilon_;
-  bool calc_curvature_with_2_poses_;
 
   ros::Subscriber sub_path_;
   ros::Subscriber sub_path_velocity_;
@@ -170,7 +169,6 @@ TrackerNode::TrackerNode()
   pnh_.param("limit_vel_by_avel", limit_vel_by_avel_, false);
   pnh_.param("check_old_path", check_old_path_, false);
   pnh_.param("epsilon", epsilon_, 0.001);
-  pnh_.param("calc_curvature_with_2_poses", calc_curvature_with_2_poses_, false);
 
   sub_path_ = neonavigation_common::compat::subscribe<nav_msgs::Path>(
       nh_, "path",
@@ -389,9 +387,7 @@ void TrackerNode::control()
   angle = trajectory_tracker::angleNormalized(angle);
 
   // Curvature
-  const float curv = calc_curvature_with_2_poses_ ?
-                         lpath.getCurvatureWith2Poses(it_nearest, it_local_goal, pos_on_line, curv_forward_) :
-                         lpath.getCurvatureWith3Points(it_nearest, it_local_goal, pos_on_line, curv_forward_);
+  const float curv = lpath.getCurvature(it_nearest, it_local_goal, pos_on_line, curv_forward_);
 
   status.distance_remains = remain;
   status.angle_remains = angle;

--- a/trajectory_tracker/src/trajectory_tracker.cpp
+++ b/trajectory_tracker/src/trajectory_tracker.cpp
@@ -107,6 +107,7 @@ private:
   bool limit_vel_by_avel_;
   bool check_old_path_;
   double epsilon_;
+  bool calc_curvature_with_2_poses_;
 
   ros::Subscriber sub_path_;
   ros::Subscriber sub_path_velocity_;
@@ -169,6 +170,7 @@ TrackerNode::TrackerNode()
   pnh_.param("limit_vel_by_avel", limit_vel_by_avel_, false);
   pnh_.param("check_old_path", check_old_path_, false);
   pnh_.param("epsilon", epsilon_, 0.001);
+  pnh_.param("calc_curvature_with_2_poses", calc_curvature_with_2_poses_, false);
 
   sub_path_ = neonavigation_common::compat::subscribe<nav_msgs::Path>(
       nh_, "path",
@@ -387,7 +389,9 @@ void TrackerNode::control()
   angle = trajectory_tracker::angleNormalized(angle);
 
   // Curvature
-  const float curv = lpath.getCurvature(it_nearest, it_local_goal, pos_on_line, curv_forward_);
+  const float curv = calc_curvature_with_2_poses_ ?
+                         lpath.getCurvatureWith3Points(it_nearest, it_local_goal, pos_on_line, curv_forward_) :
+                         lpath.getCurvatureWith2Poses(it_nearest, it_local_goal, pos_on_line, curv_forward_);
 
   status.distance_remains = remain;
   status.angle_remains = angle;

--- a/trajectory_tracker/test/src/test_path2d.cpp
+++ b/trajectory_tracker/test/src/test_path2d.cpp
@@ -82,8 +82,7 @@ TEST(Path2D, Curvature)
     trajectory_tracker::Path2D path;
     for (double a = 0; a < 1.57; a += 0.1)
       path.push_back(trajectory_tracker::Pose2D(Eigen::Vector2d(std::cos(a), std::sin(a)) * c, a + M_PI / 2, 1));
-    ASSERT_NEAR(path.getCurvatureWith3Points(path.begin(), path.end(), path[0].pos_, 10.0), 1.0 / c, 1e-2);
-    ASSERT_NEAR(path.getCurvatureWith2Poses(path.begin(), path.end(), path[0].pos_, 10.0), 1.0 / c, 1e-2);
+    ASSERT_NEAR(path.getCurvature(path.begin(), path.end(), path[0].pos_, 10.0), 1.0 / c, 1e-2);
   }
 
   for (float c = 1.0; c < 4.0; c += 0.4)
@@ -91,9 +90,7 @@ TEST(Path2D, Curvature)
     trajectory_tracker::Path2D path;
     for (double a = 0; a < 0.2; a += 0.1)
       path.push_back(trajectory_tracker::Pose2D(Eigen::Vector2d(std::cos(a), std::sin(a)) * c, a + M_PI / 2, 1));
-    ASSERT_NEAR(path.getCurvatureWith2Poses(path.begin(), path.end(), path[0].pos_, 10.0), 1.0 / c, 1e-2);
-    // Return 0 as only two points are remained in path.
-    ASSERT_FLOAT_EQ(path.getCurvatureWith3Points(path.begin(), path.end(), path[0].pos_, 10.0), 0.0);
+    ASSERT_NEAR(path.getCurvature(path.begin(), path.end(), path[0].pos_, 10.0), 1.0 / c, 1e-2);
   }
 }
 

--- a/trajectory_tracker/test/src/test_path2d.cpp
+++ b/trajectory_tracker/test/src/test_path2d.cpp
@@ -81,9 +81,19 @@ TEST(Path2D, Curvature)
   {
     trajectory_tracker::Path2D path;
     for (double a = 0; a < 1.57; a += 0.1)
-      path.push_back(trajectory_tracker::Pose2D(Eigen::Vector2d(std::cos(a), std::sin(a)) * c, 0, 1));
+      path.push_back(trajectory_tracker::Pose2D(Eigen::Vector2d(std::cos(a), std::sin(a)) * c, a + M_PI / 2, 1));
+    ASSERT_NEAR(path.getCurvatureWith3Points(path.begin(), path.end(), path[0].pos_, 10.0), 1.0 / c, 1e-2);
+    ASSERT_NEAR(path.getCurvatureWith2Poses(path.begin(), path.end(), path[0].pos_, 10.0), 1.0 / c, 1e-2);
+  }
 
-    ASSERT_NEAR(path.getCurvature(path.begin(), path.end(), path[0].pos_, 10.0), 1.0 / c, 1e-2);
+  for (float c = 1.0; c < 4.0; c += 0.4)
+  {
+    trajectory_tracker::Path2D path;
+    for (double a = 0; a < 0.2; a += 0.1)
+      path.push_back(trajectory_tracker::Pose2D(Eigen::Vector2d(std::cos(a), std::sin(a)) * c, a + M_PI / 2, 1));
+    ASSERT_NEAR(path.getCurvatureWith2Poses(path.begin(), path.end(), path[0].pos_, 10.0), 1.0 / c, 1e-2);
+    // Return 0 as only two points are remained in path.
+    ASSERT_FLOAT_EQ(path.getCurvatureWith3Points(path.begin(), path.end(), path[0].pos_, 10.0), 0.0);
   }
 }
 


### PR DESCRIPTION
The current trajectory_tracker uses 3 points to calculate curvature.
Thus, when the last motion primitive of the path is a curve, it cannot calculate its curvature.
This causes path tracking failures even in gazebo simulator.

With this PR, it can calculate the curvature of the last motion primitive using the logic same as planner_cspace::planner_3d::RotationCache.

The "planned_path" in the following results consists of consecutive single motion primitive (x: 0.3[m], y: 0.1[m], yaw, PI/4[rad], curvature: 2.426)

master branch (gazebo simulator):
orange: planned path, pink: actual path
The robot could not track the path and stopped as the distance between the path and the robot became more than 0.1m.
![Screenshot from 2020-01-28 21-32-54](https://user-images.githubusercontent.com/8833040/73264399-0511fc80-4216-11ea-8cc1-6f48370ab91b.png)

This PR (gazebo simulator):
The robot successfully reached the goal.
![Screenshot from 2020-01-30 14-56-51](https://user-images.githubusercontent.com/8833040/73426367-72896e80-4377-11ea-93c5-1a9a69e54634.png)

This PR (actual robot)
I tried several times and no path tracking failure happened.
![Screenshot from 2020-01-30 15-32-26](https://user-images.githubusercontent.com/8833040/73426398-8a60f280-4377-11ea-987e-739c1bbf04b7.png)
