### PR TITLE
planner_cspace: fix condition of planning finish

### DIFF
--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1393,9 +1393,7 @@ public:
           else if (yaw_diff < -M_PI)
             yaw_diff += M_PI * 2.0;
           if (std::abs(yaw_diff) <
-                      act_tolerant_->isActive() ?
-                  goal_tolerant_->goal_tolerance_ang_finish :
-                  goal_tolerance_ang_finish_)
+              (act_tolerant_->isActive() ? goal_tolerant_->goal_tolerance_ang_finish : goal_tolerance_ang_finish_))
           {
             status_.status = planner_cspace_msgs::PlannerStatus::DONE;
             has_goal_ = false;


### PR DESCRIPTION
The priority of `?` operator is lower than `<` operator, so this if-clause always returned true.