### PR TITLE
track_odometry: increase transform timeout in tests

### DIFF
--- a/track_odometry/test/src/test_tf_projection_node.cpp
+++ b/track_odometry/test/src/test_tf_projection_node.cpp
@@ -58,7 +58,7 @@ public:
 
 TEST_P(TfProjectionTest, ProjectionTransform)
 {
-  EXPECT_TRUE(tfbuf_.canTransform("map", projected_frame_, ros::Time(0), ros::Duration(1.0)));
+  EXPECT_TRUE(tfbuf_.canTransform("map", projected_frame_, ros::Time(0), ros::Duration(10.0)));
 
   geometry_msgs::TransformStamped out;
   try


### PR DESCRIPTION
fix #489 