### PR TITLE
Fix duplicated tf timestamp

### DIFF
--- a/planner_cspace/include/planner_cspace/jump_detector.h
+++ b/planner_cspace/include/planner_cspace/jump_detector.h
@@ -47,7 +47,6 @@ class JumpDetector
 {
 protected:
   tf2_ros::Buffer& tfbuf_;
-  tf2_ros::TransformListener tfl_;
   tf2::Transform base_trans_prev_;
   tf2::Transform map_trans_prev_;
 
@@ -62,7 +61,6 @@ protected:
 public:
   explicit JumpDetector(tf2_ros::Buffer& tfbuf)
     : tfbuf_(tfbuf)
-    , tfl_(tfbuf_)
     , base_trans_prev_(tf2::Quaternion(0, 0, 0, 1))
     , map_trans_prev_(tf2::Quaternion(0, 0, 0, 1))
     , init_(false)

--- a/planner_cspace/test/src/test_navigate_boundary.cpp
+++ b/planner_cspace/test/src/test_navigate_boundary.cpp
@@ -64,7 +64,7 @@ protected:
   void publishTransform(const double x, const double y)
   {
     geometry_msgs::TransformStamped trans;
-    trans.header.stamp = ros::Time();
+    trans.header.stamp = ros::Time::now();
     trans.header.frame_id = "odom";
     trans.child_frame_id = "base_link";
     trans.transform.translation.x = x;
@@ -120,7 +120,7 @@ TEST_F(NavigateBoundary, StartPositionScan)
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "test_navigate");
+  ros::init(argc, argv, "test_navigate_boundary");
 
   return RUN_ALL_TESTS();
 }

--- a/trajectory_tracker/test/src/test_trajectory_tracker.cpp
+++ b/trajectory_tracker/test/src/test_trajectory_tracker.cpp
@@ -59,6 +59,7 @@ private:
   ros::Publisher pub_path_vel_;
   tf2_ros::TransformBroadcaster tfb_;
   ros::Time cmd_vel_time_;
+  ros::Time trans_stamp_last_;
 
 protected:
   std_msgs::Header last_path_header_;
@@ -207,7 +208,12 @@ public:
     trans.transform.rotation.y = q.y();
     trans.transform.rotation.z = q.z();
     trans.transform.rotation.w = q.w();
-    tfb_.sendTransform(trans);
+
+    if (trans.header.stamp != trans_stamp_last_)
+    {
+      tfb_.sendTransform(trans);
+    }
+    trans_stamp_last_ = trans.header.stamp;
   }
 };
 


### PR DESCRIPTION
which causes huge amount of warnings on geometry2 0.7.1

fix #495 