### PR TITLE
planner_cspace: avoid showing too many warning messages

### DIFF
--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1367,9 +1367,9 @@ public:
       {
         if (last_costmap_ + costmap_watchdog_ < now)
         {
-          ROS_WARN(
-              "Navigation is stopping since the costmap is too old (costmap: %0.3f)",
-              last_costmap_.toSec());
+          ROS_WARN_THROTTLE(1.0,
+                            "Navigation is stopping since the costmap is too old (costmap: %0.3f)",
+                            last_costmap_.toSec());
           status_.error = planner_cspace_msgs::PlannerStatus::DATA_MISSING;
           publishEmptyPath();
           previous_path.poses.clear();


### PR DESCRIPTION
Currently, too many warning messages are displayed until planner_3d receives the first costmap.