### PR TITLE
joystick_interrupt: send zero twist when interrupt button is released

### DIFF
--- a/joystick_interrupt/src/joystick_interrupt.cpp
+++ b/joystick_interrupt/src/joystick_interrupt.cpp
@@ -59,6 +59,15 @@ private:
   int high_speed_button_;
   ros::Time last_joy_msg_;
 
+  void publishTwist(const float lin, const float ang)
+  {
+    geometry_msgs::Twist cmd_vel;
+    cmd_vel.linear.x = lin * linear_vel_;
+    cmd_vel.linear.y = cmd_vel.linear.z = 0.0;
+    cmd_vel.angular.z = ang * angular_vel_;
+    cmd_vel.angular.x = cmd_vel.angular.y = 0.0;
+    pub_twist_.publish(cmd_vel);
+  }
   void cbJoy(const sensor_msgs::Joy::Ptr msg)
   {
     if (static_cast<size_t>(interrupt_button_) >= msg->buttons.size())
@@ -70,6 +79,10 @@ private:
     }
     if (!msg->buttons[interrupt_button_])
     {
+      if (last_joy_msg_ != ros::Time(0))
+      {
+        publishTwist(0, 0);
+      }
       last_joy_msg_ = ros::Time(0);
       return;
     }
@@ -126,13 +139,7 @@ private:
         ROS_ERROR("Out of range: number of buttons (%lu) must be greater than high_speed_button (%d).",
                   msg->buttons.size(), high_speed_button_);
     }
-
-    geometry_msgs::Twist cmd_vel;
-    cmd_vel.linear.x = lin * linear_vel_;
-    cmd_vel.linear.y = cmd_vel.linear.z = 0.0;
-    cmd_vel.angular.z = ang * angular_vel_;
-    cmd_vel.angular.x = cmd_vel.angular.y = 0.0;
-    pub_twist_.publish(cmd_vel);
+    publishTwist(lin , ang);
   };
   void cbTwist(const geometry_msgs::Twist::Ptr msg)
   {

--- a/joystick_interrupt/test/src/test_joystick_interrupt.cpp
+++ b/joystick_interrupt/test/src/test_joystick_interrupt.cpp
@@ -169,6 +169,9 @@ TEST_F(JoystickInterruptTest, Interrupt)
 TEST_F(JoystickInterruptTest, InterruptNoTwistInput)
 {
   ros::Duration(1.0).sleep();
+  // make sure the internal state of the joystick interrupt node
+  // (i.e. last_input_twist_) is set back to a zero twist.
+  publishCmdVel(0, 0);
   ros::Rate rate(20);
   for (size_t i = 0; i < 20; ++i)
   {

--- a/joystick_interrupt/test/src/test_joystick_interrupt.cpp
+++ b/joystick_interrupt/test/src/test_joystick_interrupt.cpp
@@ -10,8 +10,8 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the copyright holder nor the names of its 
- *       contributors may be used to endorse or promote products derived from 
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -162,6 +162,44 @@ TEST_F(JoystickInterruptTest, Interrupt)
     {
       ASSERT_NEAR(cmd_vel_->linear.x, 0.0, 1e-3);
       ASSERT_NEAR(cmd_vel_->angular.z, 1.0, 1e-3);
+    }
+  }
+}
+
+TEST_F(JoystickInterruptTest, InterruptNoTwistInput)
+{
+  ros::Duration(1.0).sleep();
+  ros::Rate rate(20);
+  for (size_t i = 0; i < 20; ++i)
+  {
+    if (i < 5)
+      publishJoy(0, 0, 0, 0, 0, 0);
+    else if (i < 10)
+      publishJoy(1, 0, 1, 0.5, 0, 0);
+    else if (i < 15)
+      publishJoy(0, 0, 1, 0, 0, 0);
+    else
+      publishJoy(0, 0, 0, 0.5, 0, 0);
+
+    rate.sleep();
+    ros::spinOnce();
+    if (i < 3)
+      continue;
+    ASSERT_TRUE(static_cast<bool>(cmd_vel_));
+    if (i < 5)
+    {
+      ASSERT_NEAR(cmd_vel_->linear.x, 0, 1e-3);
+      ASSERT_NEAR(cmd_vel_->angular.z, 0, 1e-3);
+    }
+    else if (i < 10)
+    {
+      ASSERT_NEAR(cmd_vel_->linear.x, 1.0, 1e-3);
+      ASSERT_NEAR(cmd_vel_->angular.z, 0.5, 1e-3);
+    }
+    else
+    {
+      ASSERT_NEAR(cmd_vel_->linear.x, 0, 1e-3);
+      ASSERT_NEAR(cmd_vel_->angular.z, 0, 1e-3);
     }
   }
 }


### PR DESCRIPTION
## Goal
- When the interrupt button is released, no new twist were published.
Systems relying on the most recent twist could potentially continue
executing a non zero twist even if the interrupt button has been released.

## Solution
- Send a zero twist when the interrupt button was pressed and is released.