### PR TITLE
trajectory_tracker: make trajectory_tracker dynamic-reconfigurable

### DIFF
--- a/trajectory_tracker/CMakeLists.txt
+++ b/trajectory_tracker/CMakeLists.txt
@@ -4,6 +4,7 @@ project(trajectory_tracker)
 set(CATKIN_DEPENDS
   roscpp
 
+  dynamic_reconfigure
   geometry_msgs
   interactive_markers
   nav_msgs
@@ -19,6 +20,11 @@ set(CATKIN_DEPENDS
 find_package(catkin REQUIRED COMPONENTS ${CATKIN_DEPENDS})
 find_package(Boost REQUIRED COMPONENTS thread)
 find_package(Eigen3 REQUIRED)
+
+generate_dynamic_reconfigure_options(
+  cfg/TrajectoryTracker.cfg
+)
+
 catkin_package(
   CATKIN_DEPENDS ${CATKIN_DEPENDS}
 )
@@ -32,7 +38,7 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_executable(trajectory_tracker src/trajectory_tracker.cpp)
 target_link_libraries(trajectory_tracker ${catkin_LIBRARIES})
-add_dependencies(trajectory_tracker ${catkin_EXPORTED_TARGETS})
+add_dependencies(trajectory_tracker ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 
 add_executable(trajectory_recorder src/trajectory_recorder.cpp)
 target_link_libraries(trajectory_recorder ${catkin_LIBRARIES})

--- a/trajectory_tracker/cfg/TrajectoryTracker.cfg
+++ b/trajectory_tracker/cfg/TrajectoryTracker.cfg
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+PACKAGE = "trajectory_tracker"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("look_forward", double_t, 0, "", 0.5, 0.0, 100.0)
+gen.add("curv_forward", double_t, 0, "", 0.5, 0.0, 100.0)
+gen.add("k_dist", double_t, 0, "", 1.0, 0.0, 100.0)
+gen.add("k_ang", double_t, 0, "", 1.0, 0.0, 100.0)
+gen.add("k_avel", double_t, 0, "", 1.0, 0.0, 100.0)
+gen.add("gain_at_vel", double_t, 0, "", 0.0, 0.0, 100.0)
+gen.add("dist_lim", double_t, 0, "", 0.5, 0.0, 100.0)
+gen.add("dist_stop", double_t, 0, "", 2.0, 0.0, 100.0)
+gen.add("rotate_ang", double_t, 0, "", 0.78539816339, 0.0, 3.1415)
+gen.add("max_vel", double_t, 0, "", 0.5, 0.0, 100.0)
+gen.add("max_angvel", double_t, 0, "", 1.0, 0.0, 100.0)
+gen.add("max_acc", double_t, 0, "", 1.0, 0.0, 100.0)
+gen.add("max_angacc", double_t, 0, "", 2.0, 0.0, 100.0)
+gen.add("acc_toc_factor", double_t, 0, "", 0.9, 0.0, 1.0)
+gen.add("angacc_toc_factor", double_t, 0, "", 0.9, 0.0, 1.0)
+gen.add("path_step", int_t, 0, "", 1, 1, 100)
+gen.add("goal_tolerance_dist", double_t, 0, "", 0.2, 0.0, 100.0)
+gen.add("goal_tolerance_ang", double_t, 0, "", 0.1, 0.0, 100.0)
+gen.add("stop_tolerance_dist", double_t, 0, "", 0.1, 0.0, 100.0)
+gen.add("stop_tolerance_ang", double_t, 0, "", 0.05, 0.0, 100.0)
+gen.add("no_position_control_dist", double_t, 0, "", 0.0, 0.0, 100.0)
+gen.add("min_tracking_path", double_t, 0, "", 0.0, 0.0, 100.0)
+gen.add("allow_backward", bool_t, 0, "", True)
+gen.add("limit_vel_by_avel", bool_t, 0, "", False)
+gen.add("check_old_path", bool_t, 0, "", False)
+gen.add("epsilon", double_t, 0, "", 0.001, 0.0, 10.0)
+
+exit(gen.generate(PACKAGE, "trajectory_tracker", "TrajectoryTracker"))

--- a/trajectory_tracker/package.xml
+++ b/trajectory_tracker/package.xml
@@ -14,6 +14,7 @@
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
 
+  <depend>dynamic_reconfigure</depend>
   <depend>geometry_msgs</depend>
   <depend>interactive_markers</depend>
   <depend>nav_msgs</depend>


### PR DESCRIPTION
By this PR, parameters of trajectory_tracker can be changed while the node is running using dynamic_reconfigure.
It makes easy to adjust parameters.