### PR TITLE
planner_cspace: avoid publishing invalid path when escaping

### DIFF
--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1620,13 +1620,6 @@ protected:
       if (remain.sqlen() <= g_tolerance_lin * g_tolerance_lin &&
           std::abs(remain[2]) <= g_tolerance_ang)
       {
-        path.poses.resize(1);
-        path.poses[0].header = path.header;
-        if (force_goal_orientation_)
-          path.poses[0].pose = goal_raw_.pose;
-        else
-          path.poses[0].pose = ge;
-
         if (escaping_)
         {
           goal_ = goal_raw_;
@@ -1636,6 +1629,13 @@ protected:
         }
         else
         {
+          path.poses.resize(1);
+          path.poses[0].header = path.header;
+          if (force_goal_orientation_)
+            path.poses[0].pose = goal_raw_.pose;
+          else
+            path.poses[0].pose = ge;
+
           status_.status = planner_cspace_msgs::PlannerStatus::FINISHING;
           ROS_INFO("Path plan finishing");
         }


### PR DESCRIPTION
When "Goal is in Rock", an empty path and a path including only the goal pose are published alternately as follows.

```
---
header: 
  seq: 28301
  stamp: 
    secs: 7080
    nsecs:   8000000
  frame_id: "map"
poses: []
---
header: 
  seq: 28302
  stamp: 
    secs: 7080
    nsecs: 502000000
  frame_id: "map"
poses: 
  - 
    header: 
      seq: 3
      stamp: 
        secs: 7080
        nsecs: 502000000
      frame_id: "map"
    pose: 
      position: 
        x: -2.69430923462
        y: 13.590215683
        z: 0.0
      orientation: 
        x: 0.0
        y: 0.0
        z: 0.702808114546
        w: 0.711379472665
---
header: 
  seq: 28303
  stamp: 
    secs: 7081
    nsecs:   9000000
  frame_id: "map"
poses: []
---
header: 
  seq: 28304
  stamp: 
    secs: 7081
    nsecs: 511000000
  frame_id: "map"
poses: 
  - 
    header: 
      seq: 3
      stamp: 
        secs: 7081
        nsecs: 511000000
      frame_id: "map"
    pose: 
      position: 
        x: -2.69430923462
        y: 13.590215683
        z: 0.0
      orientation: 
        x: 0.0
        y: 0.0
        z: 0.702808114546
        w: 0.711379472665
---
header: 
  seq: 28305
  stamp: 
    secs: 7082
    nsecs:   7000000
  frame_id: "map"
poses: []
```

This PR fixes that bug. 