### PR TITLE
costmap_cspace: enable func to remove objects out of z range

### DIFF
--- a/costmap_cspace/src/laserscan_to_map.cpp
+++ b/costmap_cspace/src/laserscan_to_map.cpp
@@ -74,8 +74,8 @@ public:
     , tfl_(tfbuf_)
   {
     neonavigation_common::compat::checkCompatMode();
-    pnh_.param("z_min", z_min_, 0.1);
-    pnh_.param("z_max", z_max_, 1.0);
+    pnh_.param("z_min", z_min_, std::numeric_limits<double>::lowest());
+    pnh_.param("z_max", z_max_, std::numeric_limits<double>::max());
     pnh_.param("global_frame", global_frame_, std::string("map"));
     pnh_.param("robot_frame", robot_frame_, std::string("base_link"));
 

--- a/costmap_cspace/src/laserscan_to_map.cpp
+++ b/costmap_cspace/src/laserscan_to_map.cpp
@@ -129,6 +129,7 @@ private:
       return;
     published_ = now;
 
+    float robot_z;
     try
     {
       tf2::Stamped<tf2::Transform> trans;
@@ -143,6 +144,7 @@ private:
       map.info.origin.orientation.w = 1.0;
       origin_x_ = x - width_ * map.info.resolution * 0.5;
       origin_y_ = y - height_ * map.info.resolution * 0.5;
+      robot_z = pos.z();
     }
     catch (tf2::TransformException& e)
     {
@@ -156,8 +158,11 @@ private:
     {
       auto itr_x = sensor_msgs::PointCloud2ConstIterator<float>(pc, "x");
       auto itr_y = sensor_msgs::PointCloud2ConstIterator<float>(pc, "y");
+      auto itr_z = sensor_msgs::PointCloud2ConstIterator<float>(pc, "z");
       for (; itr_x != itr_x.end(); ++itr_x, ++itr_y)
       {
+        if (*itr_z - robot_z < z_min_ || z_max_ < *itr_z - robot_z)
+          continue;
         unsigned int x = int(
             (*itr_x - map.info.origin.position.x) / map.info.resolution);
         unsigned int y = int(

--- a/costmap_cspace/src/laserscan_to_map.cpp
+++ b/costmap_cspace/src/laserscan_to_map.cpp
@@ -36,6 +36,7 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2_sensor_msgs/tf2_sensor_msgs.h>
 
+#include <limits>
 #include <string>
 
 #include <costmap_cspace/pointcloud_accumulator.h>


### PR DESCRIPTION
`LaserscanToMapNode` has `z_min_` and `z_max_` params as well as `Pointcloud2ToMapNode`.
However, `LaserscanToMapNode` never use it.
Therefore, I added the function to remove out of z range objects as in `Pointcloud2ToMapNode`.
