### PR TITLE
costmap_cspace: make Costmap3dLayerPlain and Costmap3dLayerOutput faster

### DIFF
--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/base.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/base.h
@@ -77,6 +77,20 @@ public:
 
     return data[addr];
   }
+  static void copyCells(CSpace3DMsg& to, const int& to_x, const int& to_y, const int& to_yaw,
+                        const CSpace3DMsg& from, const int& from_x, const int& from_y, const int& from_yaw,
+                        const int& copy_cell_num)
+  {
+    std::memcpy(to.data.data() + to.address(to_x, to_y, to_yaw),
+                from.data.data() + from.address(from_x, from_y, from_yaw), copy_cell_num * sizeof(int8_t));
+  }
+  static void copyCells(costmap_cspace_msgs::CSpace3DUpdate& to, const int& to_x, const int& to_y, const int& to_yaw,
+                        const CSpace3DMsg& from, const int& from_x, const int& from_y, const int& from_yaw,
+                        const int& copy_cell_num)
+  {
+    std::memcpy(to.data.data() + (to_yaw * to.height + to_y) * to.width + to_x,
+                from.data.data() + from.address(from_x, from_y, from_yaw), copy_cell_num * sizeof(int8_t));
+  }
 };
 
 enum MapOverlayMode

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/footprint.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/footprint.h
@@ -237,12 +237,13 @@ protected:
         const int res_up = std::ceil(resolution_scale);
         for (int yp = 0; yp < res_up; yp++)
         {
+          const int y2 = y + oy + yp;
+          if (static_cast<size_t>(y2) >= map->info.height)
+            continue;
           for (int xp = 0; xp < res_up; xp++)
           {
             const int x2 = x + ox + xp;
-            const int y2 = y + oy + yp;
-            if (static_cast<size_t>(x2) >= map->info.width ||
-                static_cast<size_t>(y2) >= map->info.height)
+            if (static_cast<size_t>(x2) >= map->info.width)
               continue;
 
             map->getCost(x2, y2, yaw) = -1;
@@ -282,17 +283,17 @@ protected:
     }
     for (size_t i = 0; i < msg->data.size(); i++)
     {
-      const int gx = std::lround((i % msg->info.width) * resolution_scale) + ox;
-      const int gy = std::lround((i / msg->info.width) * resolution_scale) + oy;
-      if (static_cast<size_t>(gx) >= map->info.width ||
-          static_cast<size_t>(gy) >= map->info.height)
-        continue;
       const int8_t val = msg->data[i];
       if (val < 0)
       {
         continue;
       }
-      else if (val == 0)
+      const int gx = std::lround((i % msg->info.width) * resolution_scale) + ox;
+      const int gy = std::lround((i / msg->info.width) * resolution_scale) + oy;
+      if (static_cast<size_t>(gx) >= map->info.width ||
+          static_cast<size_t>(gy) >= map->info.height)
+        continue;
+      if (val == 0)
       {
         int8_t& m = map->getCost(gx, gy, yaw);
         if (m < 0)

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/output.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/output.h
@@ -106,7 +106,22 @@ protected:
     update_msg->yaw = region_merged.yaw_;
     update_msg->angle = region_merged.angle_;
     update_msg->data.resize(update_msg->width * update_msg->height * update_msg->angle);
-    std::memcpy(update_msg->data.data(), &(map_->getCost(0, 0, 0)), update_msg->data.size() * sizeof(int8_t));
+    if ((update_msg->x == 0) && (update_msg->y == 0) && (update_msg->yaw == 0) &&
+        (update_msg->width == map_->info.width) && (update_msg->height == map_->info.height) &&
+        (update_msg->angle == map_->info.angle))
+    {
+      std::memcpy(update_msg->data.data(), &(map_->getCost(0, 0, 0)), update_msg->data.size() * sizeof(int8_t));
+      return update_msg;
+    }
+    for (unsigned int k = 0; k < update_msg->angle; ++k)
+    {
+      for (unsigned int j = 0; j < update_msg->height; ++j)
+      {
+        const int8_t* const map_addr = &(map_->getCost(update_msg->x, update_msg->y + j, update_msg->yaw + k));
+        int8_t* const msg_addr = update_msg->data.data() + (k * update_msg->height + j) * update_msg->width;
+        std::memcpy(msg_addr, map_addr, update_msg->width * sizeof(int8_t));
+      }
+    }
     return update_msg;
   }
 };

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/output.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/output.h
@@ -110,16 +110,15 @@ protected:
         (update_msg->width == map_->info.width) && (update_msg->height == map_->info.height) &&
         (update_msg->angle == map_->info.angle))
     {
-      std::memcpy(update_msg->data.data(), &(map_->getCost(0, 0, 0)), update_msg->data.size() * sizeof(int8_t));
+      CSpace3DMsg::copyCells(*update_msg, 0, 0, 0, *map_, 0, 0, 0, update_msg->data.size());
       return update_msg;
     }
     for (unsigned int k = 0; k < update_msg->angle; ++k)
     {
       for (unsigned int j = 0; j < update_msg->height; ++j)
       {
-        const int8_t* const map_addr = &(map_->getCost(update_msg->x, update_msg->y + j, update_msg->yaw + k));
-        int8_t* const msg_addr = update_msg->data.data() + (k * update_msg->height + j) * update_msg->width;
-        std::memcpy(msg_addr, map_addr, update_msg->width * sizeof(int8_t));
+        CSpace3DMsg::copyCells(*update_msg, 0, j, k,
+                               *map_, update_msg->x, update_msg->y + j, update_msg->yaw + k, update_msg->width);
       }
     }
     return update_msg;

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/output.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/output.h
@@ -32,10 +32,10 @@
 
 #include <memory>
 
-#include <geometry_msgs/PolygonStamped.h>
-#include <nav_msgs/OccupancyGrid.h>
 #include <costmap_cspace_msgs/CSpace3D.h>
 #include <costmap_cspace_msgs/CSpace3DUpdate.h>
+#include <geometry_msgs/PolygonStamped.h>
+#include <nav_msgs/OccupancyGrid.h>
 
 #include <costmap_cspace/costmap_3d_layer/base.h>
 
@@ -106,25 +106,7 @@ protected:
     update_msg->yaw = region_merged.yaw_;
     update_msg->angle = region_merged.angle_;
     update_msg->data.resize(update_msg->width * update_msg->height * update_msg->angle);
-
-    for (int i = 0; i < static_cast<int>(update_msg->width); i++)
-    {
-      for (int j = 0; j < static_cast<int>(update_msg->height); j++)
-      {
-        for (int k = 0; k < static_cast<int>(update_msg->angle); k++)
-        {
-          const int x2 = update_msg->x + i;
-          const int y2 = update_msg->y + j;
-          const int yaw2 = update_msg->yaw + k;
-
-          const auto& m = map_->getCost(x2, y2, yaw2);
-          const size_t addr = (k * update_msg->height + j) * update_msg->width + i;
-          ROS_ASSERT(addr < update_msg->data.size());
-          auto& up = update_msg->data[addr];
-          up = m;
-        }
-      }
-    }
+    std::memcpy(update_msg->data.data(), &(map_->getCost(0, 0, 0)), update_msg->data.size() * sizeof(int8_t));
     return update_msg;
   }
 };

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/plain.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/plain.h
@@ -73,11 +73,9 @@ protected:
     ROS_ASSERT(ang_grid_ > 0);
     clearTravelableArea(map, msg);
     generateSpecifiedCSpace(map, msg, 0);
-    const int8_t* const org_addr = &(map->getCost(0, 0, 0));
     for (size_t i = 1; i < map->info.angle; ++i)
     {
-      int8_t* const target_addr = &(map->getCost(0, 0, i));
-      std::memcpy(target_addr, org_addr, map->info.width * map->info.height * sizeof(int8_t));
+      CSpace3DMsg::copyCells(*map, 0, 0, i, *map, 0, 0, 0, map->info.width * map->info.height);
     }
   }
 };

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/plain.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/plain.h
@@ -32,12 +32,13 @@
 
 #include <memory>
 
-#include <geometry_msgs/PolygonStamped.h>
-#include <nav_msgs/OccupancyGrid.h>
 #include <costmap_cspace_msgs/CSpace3D.h>
 #include <costmap_cspace_msgs/CSpace3DUpdate.h>
+#include <geometry_msgs/PolygonStamped.h>
+#include <nav_msgs/OccupancyGrid.h>
 
 #include <costmap_cspace/costmap_3d_layer/base.h>
+#include <costmap_cspace/costmap_3d_layer/footprint.h>
 
 namespace costmap_cspace
 {
@@ -61,6 +62,23 @@ public:
     setExpansion(
         static_cast<double>(config["linear_expand"]),
         static_cast<double>(config["linear_spread"]));
+  }
+
+protected:
+  void generateCSpace(
+      CSpace3DMsg::Ptr map,
+      const nav_msgs::OccupancyGrid::ConstPtr& msg,
+      const UpdatedRegion& region) final
+  {
+    ROS_ASSERT(ang_grid_ > 0);
+    clearTravelableArea(map, msg);
+    generateSpecifiedCSpace(map, msg, 0);
+    const int8_t* const org_addr = &(map->getCost(0, 0, 0));
+    for (size_t i = 1; i < map->info.angle; ++i)
+    {
+      int8_t* const target_addr = &(map->getCost(0, 0, i));
+      std::memcpy(target_addr, org_addr, msg->data.size() * sizeof(int8_t));
+    }
   }
 };
 }  // namespace costmap_cspace

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/plain.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/plain.h
@@ -77,7 +77,7 @@ protected:
     for (size_t i = 1; i < map->info.angle; ++i)
     {
       int8_t* const target_addr = &(map->getCost(0, 0, i));
-      std::memcpy(target_addr, org_addr, msg->data.size() * sizeof(int8_t));
+      std::memcpy(target_addr, org_addr, map->info.width * map->info.height * sizeof(int8_t));
     }
   }
 };


### PR DESCRIPTION
Costmap3dLayerPlain: As each map does not vary with its yaw angle, only first map is generated and copied to others.
Costmap3dLayerOutput: When an entire map is updated, all memories are copied at once. Otherwise, each raster is copied.