### PR TITLE
planner_cspace: improve performance of hysteresis clearing

### DIFF
--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -148,6 +148,7 @@ protected:
   bool has_goal_;
   bool has_start_;
   bool has_hysteresis_map_;
+  std::vector<Astar::Vec> hyst_updated_cells_;
   bool goal_updated_;
   bool remember_updates_;
   bool fast_map_update_;
@@ -727,7 +728,7 @@ protected:
 
     if (goal_changed)
     {
-      cm_hyst_.clear(100);
+      clearHysteresis();
       has_hysteresis_map_ = false;
     }
 
@@ -736,6 +737,14 @@ protected:
     goal_updated_ = true;
 
     return true;
+  }
+  void clearHysteresis()
+  {
+    for (const Astar::Vec& p : hyst_updated_cells_)
+    {
+      cm_hyst_[p] = 100;
+    }
+    hyst_updated_cells_.clear();
   }
   void publishDebug()
   {
@@ -895,7 +904,7 @@ protected:
     if (clear_hysteresis && has_hysteresis_map_)
     {
       ROS_INFO("The previous path collides to the obstacle. Clearing hysteresis map.");
-      cm_hyst_.clear(100);
+      clearHysteresis();
       has_hysteresis_map_ = false;
     }
 
@@ -1139,6 +1148,7 @@ protected:
     ROS_DEBUG("Map copied");
 
     cm_hyst_.clear(100);
+    hyst_updated_cells_.clear();
     has_hysteresis_map_ = false;
 
     has_map_ = true;
@@ -1827,7 +1837,7 @@ protected:
         }
       }
 
-      cm_hyst_.clear(100);
+      clearHysteresis();
       const auto ts = boost::chrono::high_resolution_clock::now();
       for (auto& ps : path_points)
       {
@@ -1856,6 +1866,7 @@ protected:
         }
         d_min = std::max(expand_dist, std::min(expand_dist + max_dist, d_min));
         cm_hyst_[p] = std::lround((d_min - expand_dist) * 100.0 / max_dist);
+        hyst_updated_cells_.push_back(p);
       }
       has_hysteresis_map_ = true;
       const auto tnow = boost::chrono::high_resolution_clock::now();

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1837,8 +1837,8 @@ protected:
         }
       }
 
-      clearHysteresis();
       const auto ts = boost::chrono::high_resolution_clock::now();
+      clearHysteresis();
       for (auto& ps : path_points)
       {
         const Astar::Vec& p = ps.first;

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1816,6 +1816,7 @@ protected:
 
     if (hyst)
     {
+      const auto ts = boost::chrono::high_resolution_clock::now();
       std::unordered_map<Astar::Vec, bool, Astar::Vec> path_points;
       const float max_dist = cc_.hysteresis_max_dist_ / map_info_.linear_resolution;
       const float expand_dist = cc_.hysteresis_expand_ / map_info_.linear_resolution;
@@ -1837,7 +1838,6 @@ protected:
         }
       }
 
-      const auto ts = boost::chrono::high_resolution_clock::now();
       clearHysteresis();
       for (auto& ps : path_points)
       {


### PR DESCRIPTION
`cm_hyst_.clear(100);` sets the value to the whole array in `cm_hyst_`.
Especially when the map is large. it spends too much time.
This PR reduces the processing time of the clearing method by restoring only changed cells.