### PR TITLE
planner_cspace: improve performance of costmap reset

### DIFF
--- a/planner_cspace/include/planner_cspace/blockmem_gridmap.h
+++ b/planner_cspace/include/planner_cspace/blockmem_gridmap.h
@@ -45,6 +45,11 @@ public:
   virtual const CyclicVecInt<DIM, NONCYCLIC>& size() const = 0;
   virtual size_t ser_size() const = 0;
   virtual void clear(const T zero) = 0;
+  virtual void clear_partially(
+      const T zero, const CyclicVecInt<DIM, NONCYCLIC>& min, const CyclicVecInt<DIM, NONCYCLIC>& max) = 0;
+  virtual void copy_partially(
+      const BlockMemGridmapBase<T, DIM, NONCYCLIC>& base, const CyclicVecInt<DIM, NONCYCLIC>& min,
+      const CyclicVecInt<DIM, NONCYCLIC>& max) = 0;
   virtual void reset(const CyclicVecInt<DIM, NONCYCLIC>& size) = 0;
   virtual T& operator[](const CyclicVecInt<DIM, NONCYCLIC>& pos) = 0;
   virtual const T operator[](const CyclicVecInt<DIM, NONCYCLIC>& pos) const = 0;
@@ -118,6 +123,37 @@ public:
     for (size_t i = 0; i < ser_size_; i++)
     {
       c_[i] = zero;
+    }
+  }
+  void clear_partially(
+      const T zero, const CyclicVecInt<DIM, NONCYCLIC>& min, const CyclicVecInt<DIM, NONCYCLIC>& max)
+  {
+    CyclicVecInt<DIM, NONCYCLIC> p = min;
+    for (p[0] = min[0]; p[0] < max[0]; ++p[0])
+    {
+      for (p[1] = min[1]; p[1] < max[1]; ++p[1])
+      {
+        for (p[2] = min[2]; p[2] < max[2]; ++p[2])
+        {
+          (*this)[p] = zero;
+        }
+      }
+    }
+  }
+  void copy_partially(
+      const BlockMemGridmapBase<T, DIM, NONCYCLIC>& base, const CyclicVecInt<DIM, NONCYCLIC>& min,
+      const CyclicVecInt<DIM, NONCYCLIC>& max)
+  {
+    CyclicVecInt<DIM, NONCYCLIC> p = min;
+    for (p[0] = min[0]; p[0] < max[0]; ++p[0])
+    {
+      for (p[1] = min[1]; p[1] < max[1]; ++p[1])
+      {
+        for (p[2] = min[2]; p[2] < max[2]; ++p[2])
+        {
+          (*this)[p] = base[p];
+        }
+      }
     }
   }
   void clear_positive(const T zero)
@@ -213,7 +249,7 @@ public:
       const BlockMemGridmap<T, DIM, NONCYCLIC, BLOCK_WIDTH, ENABLE_VALIDATION>& gm)
   {
     reset(gm.size_);
-    memcpy(c_.get(), gm.c_.get(), ser_size_);
+    memcpy(c_.get(), gm.c_.get(), ser_size_ * sizeof(T));
 
     return *this;
   }

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -855,7 +855,7 @@ protected:
       {
         for (p[1] = prev_map_update_y_min_; p[1] < prev_map_update_y_max_; p[1]++)
         {
-          for (p[2] = 0; p[2] < map_info_.angle; p[2]++)
+          for (p[2] = 0; p[2] < static_cast<int>(map_info_.angle); p[2]++)
           {
             cm_[p] = cm_base_[p];
           }

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -849,22 +849,13 @@ protected:
     const ros::Time now = ros::Time::now();
     last_costmap_ = now;
 
-    {
-      Astar::Vec p(0, 0, 0);
-      for (p[0] = prev_map_update_x_min_; p[0] < prev_map_update_x_max_; p[0]++)
-      {
-        for (p[1] = prev_map_update_y_min_; p[1] < prev_map_update_y_max_; p[1]++)
-        {
-          for (p[2] = 0; p[2] < static_cast<int>(map_info_.angle); p[2]++)
-          {
-            cm_[p] = cm_base_[p];
-          }
-          p[2] = 0;
-          cm_rough_[p] = cm_rough_base_[p];
-          cm_updates_[p] = -1;
-        }
-      }
-    }
+    cm_.copy_partially(cm_base_, Astar::Vec(prev_map_update_x_min_, prev_map_update_y_min_, 0),
+                       Astar::Vec(prev_map_update_x_max_, prev_map_update_y_max_, static_cast<int>(map_info_.angle)));
+    cm_rough_.copy_partially(cm_rough_base_, Astar::Vec(prev_map_update_x_min_, prev_map_update_y_min_, 0),
+                             Astar::Vec(prev_map_update_x_max_, prev_map_update_y_max_, 1));
+    cm_updates_.clear_partially(-1, Astar::Vec(prev_map_update_x_min_, prev_map_update_y_min_, 0),
+                                Astar::Vec(prev_map_update_x_max_, prev_map_update_y_max_, 1));
+
     const int map_update_x_min = static_cast<int>(msg->x);
     const int map_update_x_max = static_cast<int>(msg->x + msg->width);
     const int map_update_y_min = static_cast<int>(msg->y);

--- a/planner_cspace/test/src/test_blockmem_gridmap.cpp
+++ b/planner_cspace/test/src/test_blockmem_gridmap.cpp
@@ -88,6 +88,86 @@ TEST(BlockmemGridmap, ResetClear)
   }
 }
 
+TEST(BlockmemGridmap, ClearAndCopyPartially)
+{
+  const CyclicVecInt<3, 3> base_size(17, 8, 3);
+  BlockMemGridmap<float, 3, 3, 0x20> gm_base;
+  gm_base.reset(base_size);
+  for (CyclicVecInt<3, 3> p(0, 0, 0); p[0] < base_size[0]; ++p[0])
+  {
+    for (p[1] = 0; p[1] < base_size[1]; ++p[1])
+    {
+      for (p[2] = 0; p[2] < base_size[2]; ++p[2])
+      {
+        gm_base[p] = p[0] * base_size[1] * base_size[2] + p[1] * base_size[2] + p[2];
+      }
+    }
+  }
+
+  BlockMemGridmap<float, 3, 3, 0x20> gm;
+  gm = gm_base;
+
+  const CyclicVecInt<3, 3> copy_min_pos(3, 5, 0);
+  const CyclicVecInt<3, 3> copy_max_pos(6, 7, 2);
+  gm.clear_partially(-1, copy_min_pos, copy_max_pos);
+
+  for (CyclicVecInt<3, 3> p(0, 0, 0); p[0] < base_size[0]; ++p[0])
+  {
+    for (p[1] = 0; p[1] < base_size[1]; ++p[1])
+    {
+      for (p[2] = 0; p[2] < base_size[2]; ++p[2])
+      {
+        if ((copy_min_pos[0] <= p[0]) && (p[0] < copy_max_pos[0]) &&
+            (copy_min_pos[1] <= p[1]) && (p[1] < copy_max_pos[1]) &&
+            (copy_min_pos[2] <= p[2]) && (p[2] < copy_max_pos[2]))
+        {
+          EXPECT_EQ(gm[p], -1) << p[0] << "," << p[1] << "," << p[2];
+        }
+        else
+        {
+          EXPECT_EQ(gm[p], gm_base[p]) << p[0] << "," << p[1] << "," << p[2];
+        }
+      }
+    }
+  }
+
+  BlockMemGridmap<float, 3, 3, 0x20> gm_update;
+  gm_update.reset(base_size);
+  for (CyclicVecInt<3, 3> p(0, 0, 0); p[0] < base_size[0]; ++p[0])
+  {
+    for (p[1] = 0; p[1] < base_size[1]; ++p[1])
+    {
+      for (p[2] = 0; p[2] < base_size[2]; ++p[2])
+      {
+        gm_update[p] = p[0] * base_size[1] * base_size[2] + p[1] * base_size[2] + p[2] * -1;
+      }
+    }
+  }
+
+  gm = gm_base;
+  gm.copy_partially(gm_update, copy_min_pos, copy_max_pos);
+
+  for (CyclicVecInt<3, 3> p(0, 0, 0); p[0] < base_size[0]; ++p[0])
+  {
+    for (p[1] = 0; p[1] < base_size[1]; ++p[1])
+    {
+      for (p[2] = 0; p[2] < base_size[2]; ++p[2])
+      {
+        if ((copy_min_pos[0] <= p[0]) && (p[0] < copy_max_pos[0]) &&
+            (copy_min_pos[1] <= p[1]) && (p[1] < copy_max_pos[1]) &&
+            (copy_min_pos[2] <= p[2]) && (p[2] < copy_max_pos[2]))
+        {
+          ASSERT_EQ(gm[p], gm_update[p]);
+        }
+        else
+        {
+          ASSERT_EQ(gm[p], gm_base[p]);
+        }
+      }
+    }
+  }
+}
+
 TEST(BlockmemGridmap, WriteRead)
 {
   BlockMemGridmap<float, 3, 3, 0x20> gm;


### PR DESCRIPTION
When the map is large, resetting of `cm_`, `cm_rough_` , and `cm_updates_` spends too much calculation time as it overwrites all cells in arrays of them. 
In this PR, they are partially reset using ranges of the previous local map.
When the size of map is 5000 x 3000, processing times are reduced from more than 200ms to less than 10ms.