### PR TITLE
trajectory_tracker: increase SwitchBackWithPathUpdate test timeout

### DIFF
--- a/trajectory_tracker/test/src/test_trajectory_tracker.cpp
+++ b/trajectory_tracker/test/src/test_trajectory_tracker.cpp
@@ -446,7 +446,7 @@ TEST_F(TrajectoryTrackerTest, SwitchBackWithPathUpdate)
   const ros::Time start = ros::Time::now();
   while (ros::ok())
   {
-    ASSERT_LT(ros::Time::now() - start, ros::Duration(10.0));
+    ASSERT_LT(ros::Time::now() - start, ros::Duration(15.0));
 
     publishTransform();
     rate.sleep();


### PR DESCRIPTION
SwitchBackWithPathUpdate has 1.5 times longer path than the other test cases.