### PR TITLE
Prevent broadcasting tf with same timestamp

### DIFF
--- a/track_odometry/src/tf_projection_node.cpp
+++ b/track_odometry/src/tf_projection_node.cpp
@@ -60,12 +60,14 @@ private:
   std::string parent_frame_;
   std::string projected_frame_;
   ros::Time prev_stamp_;
+  const tf2::Vector3 z_axis_;
 
 public:
   TfProjectionNode()
     : nh_()
     , pnh_("~")
     , tf_listener_(tf_buffer_)
+    , z_axis_(0, 0, 1)
   {
     if (pnh_.hasParam("base_link_frame") ||
         pnh_.hasParam("projection_frame") ||
@@ -123,14 +125,14 @@ public:
       if (align_all_posture_to_source_)
       {
         const tf2::Quaternion rot(trans.getRotation());
-        const tf2::Quaternion rot_yaw(tf2::Vector3(0.0, 0.0, 1.0), tf2::getYaw(rot));
+        const tf2::Quaternion rot_yaw(z_axis_, tf2::getYaw(rot));
         const tf2::Transform rot_inv(rot_yaw * rot.inverse());
         trans.setData(rot_inv * trans);
       }
       else
       {
         const float yaw = tf2::getYaw(trans.getRotation());
-        trans.setRotation(tf2::Quaternion(tf2::Vector3(0.0, 0.0, 1.0), yaw));
+        trans.setRotation(tf2::Quaternion(z_axis_, yaw));
       }
     }
 
@@ -145,7 +147,7 @@ public:
       if (flat_)
       {
         const double yaw = tf2::getYaw(trans_out.transform.rotation);
-        trans_out.transform.rotation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0.0, 0.0, 1.0), yaw));
+        trans_out.transform.rotation = tf2::toMsg(tf2::Quaternion(z_axis_, yaw));
       }
       trans_out.child_frame_id = projected_frame_;
 

--- a/track_odometry/test/test/tf_projection_rostest.test
+++ b/track_odometry/test/test/tf_projection_rostest.test
@@ -5,10 +5,10 @@
   <test test-name="test_tf_projection_node" pkg="track_odometry" type="test_tf_projection_node" />
 
   <node pkg="track_odometry" type="tf_projection" name="tf_projection">
-    <param name="base_link_frame" value="base_link" />
-    <param name="projection_frame" value="map" />
-    <param name="target_frame" value="map" />
-    <param name="frame" value="base_link_projected" />
+    <param name="source_frame" value="base_link" />
+    <param name="projection_surface_frame" value="map" />
+    <param name="parent_frame" value="map" />
+    <param name="projected_frame" value="base_link_projected" />
     <param name="project_posture" value="false" />
   </node>
 


### PR DESCRIPTION
This PR aims at preventing the following warnings:
```
Warning: TF_REPEATED_DATA ignoring data with redundant timestamp for frame .... at time 1630935311.729019 according to authority unknown_publisher
         at line Warning: 278 in /tmp_ws/src/geometry2/tf2/src/buffer_core.cppTF_REPEATED_DATA ignoring data with redundant timestamp for frame odom_floor at time 1630935311.729019 according to authority unknown_publisher
```
The solution proposed is to only broadcast new transforms i.e. transforms with a greater timestamp than the previously broadcasted one. 