### PR TITLE
planner_cspace: Fix header of finish path

### DIFF
--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -667,7 +667,7 @@ protected:
   void publishFinishPath()
   {
     nav_msgs::Path path;
-    path.header.frame_id = robot_frame_;
+    path.header.frame_id = map_header_.frame_id;
     path.header.stamp = ros::Time::now();
     // Specify single pose to control only orientation
     path.poses.resize(1);


### PR DESCRIPTION
The `frame_id` of finish path should be the same as that of `goal_`.