### PR TITLE
Divide output layer class into specific classes

### DIFF
--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/output.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/output.h
@@ -41,11 +41,12 @@
 
 namespace costmap_cspace
 {
+template <class OUTPUT_MSG>
 class Costmap3dLayerOutput : public Costmap3dLayerBase
 {
 public:
   using Ptr = std::shared_ptr<Costmap3dLayerOutput>;
-  using Callback = boost::function<bool(const CSpace3DMsg::Ptr, const costmap_cspace_msgs::CSpace3DUpdate::Ptr)>;
+  using Callback = boost::function<bool(const typename OUTPUT_MSG::Ptr)>;
 
 protected:
   Callback cb_;
@@ -68,18 +69,42 @@ protected:
   {
     return 0;
   }
-  bool updateChain(const bool output)
-  {
-    auto update_msg = generateUpdateMsg();
-    if (cb_ && output)
-      return cb_(map_, update_msg);
-    return true;
-  }
   void updateCSpace(
       const nav_msgs::OccupancyGrid::ConstPtr& map,
       const UpdatedRegion& region)
   {
   }
+};
+
+class Costmap3dStaticLayerOutput : public Costmap3dLayerOutput<costmap_cspace::CSpace3DMsg>
+{
+public:
+  using Ptr = std::shared_ptr<Costmap3dStaticLayerOutput>;
+
+protected:
+  bool updateChain(const bool output)
+  {
+    if (cb_ && output)
+      return cb_(map_);
+    return true;
+  }
+};
+
+class Costmap3dUpdateLayerOutput : public Costmap3dLayerOutput<costmap_cspace_msgs::CSpace3DUpdate>
+{
+public:
+  using Ptr = std::shared_ptr<Costmap3dUpdateLayerOutput>;
+  using Parent = Costmap3dLayerOutput<costmap_cspace_msgs::CSpace3DUpdate>;
+
+protected:
+  bool updateChain(const bool output)
+  {
+    auto update_msg = generateUpdateMsg();
+    if (cb_ && output)
+      return cb_(update_msg);
+    return true;
+  }
+
   costmap_cspace_msgs::CSpace3DUpdate::Ptr generateUpdateMsg()
   {
     costmap_cspace_msgs::CSpace3DUpdate::Ptr update_msg(new costmap_cspace_msgs::CSpace3DUpdate);

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/output.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/output.h
@@ -41,22 +41,21 @@
 
 namespace costmap_cspace
 {
-template <class OUTPUT_MSG>
+template <class CALLBACK>
 class Costmap3dLayerOutput : public Costmap3dLayerBase
 {
 public:
   using Ptr = std::shared_ptr<Costmap3dLayerOutput>;
-  using Callback = boost::function<bool(const typename OUTPUT_MSG::Ptr)>;
 
 protected:
-  Callback cb_;
+  CALLBACK cb_;
   UpdatedRegion region_prev_;
 
 public:
   void loadConfig(XmlRpc::XmlRpcValue config)
   {
   }
-  void setHandler(Callback cb)
+  void setHandler(CALLBACK cb)
   {
     cb_ = cb;
   }
@@ -76,7 +75,8 @@ protected:
   }
 };
 
-class Costmap3dStaticLayerOutput : public Costmap3dLayerOutput<costmap_cspace::CSpace3DMsg>
+class Costmap3dStaticLayerOutput
+  : public Costmap3dLayerOutput<boost::function<bool(const typename costmap_cspace::CSpace3DMsg::Ptr&)>>
 {
 public:
   using Ptr = std::shared_ptr<Costmap3dStaticLayerOutput>;
@@ -90,18 +90,19 @@ protected:
   }
 };
 
-class Costmap3dUpdateLayerOutput : public Costmap3dLayerOutput<costmap_cspace_msgs::CSpace3DUpdate>
+class Costmap3dUpdateLayerOutput
+  : public Costmap3dLayerOutput<boost::function<bool(const typename costmap_cspace::CSpace3DMsg::Ptr&,
+                                                     const typename costmap_cspace_msgs::CSpace3DUpdate::Ptr&)>>
 {
 public:
   using Ptr = std::shared_ptr<Costmap3dUpdateLayerOutput>;
-  using Parent = Costmap3dLayerOutput<costmap_cspace_msgs::CSpace3DUpdate>;
 
 protected:
   bool updateChain(const bool output)
   {
     auto update_msg = generateUpdateMsg();
     if (cb_ && output)
-      return cb_(update_msg);
+      return cb_(map_, update_msg);
     return true;
   }
 

--- a/costmap_cspace/src/costmap_3d.cpp
+++ b/costmap_cspace/src/costmap_3d.cpp
@@ -102,13 +102,16 @@ protected:
     map->processMapOverlay(msg);
     ROS_DEBUG("C-Space costmap updated");
   }
-  bool cbUpdateStatic(const costmap_cspace::CSpace3DMsg::Ptr& map)
+  bool cbUpdateStatic(
+      const costmap_cspace::CSpace3DMsg::Ptr& map)
   {
     publishDebug(*map);
     pub_costmap_.publish<costmap_cspace_msgs::CSpace3D>(*map);
     return true;
   }
-  bool cbUpdate(const costmap_cspace::CSpace3DMsg::Ptr& map, const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update)
+  bool cbUpdate(
+      const costmap_cspace::CSpace3DMsg::Ptr& map,
+      const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update)
   {
     if (update)
     {
@@ -121,7 +124,7 @@ protected:
     }
     return true;
   }
-  void publishDebug(const costmap_cspace_msgs::CSpace3D map)
+  void publishDebug(const costmap_cspace_msgs::CSpace3D& map)
   {
     if (pub_debug_.getNumSubscribers() == 0)
       return;

--- a/costmap_cspace/src/costmap_3d.cpp
+++ b/costmap_cspace/src/costmap_3d.cpp
@@ -102,16 +102,17 @@ protected:
     map->processMapOverlay(msg);
     ROS_DEBUG("C-Space costmap updated");
   }
-  bool cbUpdateStatic(const costmap_cspace::CSpace3DMsg::Ptr map)
+  bool cbUpdateStatic(const costmap_cspace::CSpace3DMsg::Ptr& map)
   {
     publishDebug(*map);
     pub_costmap_.publish<costmap_cspace_msgs::CSpace3D>(*map);
     return true;
   }
-  bool cbUpdate(const costmap_cspace_msgs::CSpace3DUpdate::Ptr update)
+  bool cbUpdate(const costmap_cspace::CSpace3DMsg::Ptr& map, const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update)
   {
     if (update)
     {
+      publishDebug(*map);
       pub_costmap_update_.publish(*update);
     }
     else
@@ -120,7 +121,7 @@ protected:
     }
     return true;
   }
-  void publishDebug(const costmap_cspace_msgs::CSpace3D& map)
+  void publishDebug(const costmap_cspace_msgs::CSpace3D map)
   {
     if (pub_debug_.getNumSubscribers() == 0)
       return;
@@ -366,7 +367,7 @@ public:
     }
 
     auto update_output_layer = costmap_->addLayer<costmap_cspace::Costmap3dUpdateLayerOutput>();
-    update_output_layer->setHandler(boost::bind(&Costmap3DOFNode::cbUpdate, this, _1));
+    update_output_layer->setHandler(boost::bind(&Costmap3DOFNode::cbUpdate, this, _1, _2));
 
     const geometry_msgs::PolygonStamped footprint_msg = footprint.toMsg();
     timer_footprint_ = nh_.createTimer(

--- a/costmap_cspace/src/costmap_3d.cpp
+++ b/costmap_cspace/src/costmap_3d.cpp
@@ -102,21 +102,16 @@ protected:
     map->processMapOverlay(msg);
     ROS_DEBUG("C-Space costmap updated");
   }
-  bool cbUpdateStatic(
-      const costmap_cspace::CSpace3DMsg::Ptr map,
-      const costmap_cspace_msgs::CSpace3DUpdate::Ptr update)
+  bool cbUpdateStatic(const costmap_cspace::CSpace3DMsg::Ptr map)
   {
     publishDebug(*map);
     pub_costmap_.publish<costmap_cspace_msgs::CSpace3D>(*map);
     return true;
   }
-  bool cbUpdate(
-      const costmap_cspace::CSpace3DMsg::Ptr map,
-      const costmap_cspace_msgs::CSpace3DUpdate::Ptr update)
+  bool cbUpdate(const costmap_cspace_msgs::CSpace3DUpdate::Ptr update)
   {
     if (update)
     {
-      publishDebug(*map);
       pub_costmap_update_.publish(*update);
     }
     else
@@ -276,8 +271,8 @@ public:
       }
     }
 
-    auto static_output_layer = costmap_->addLayer<costmap_cspace::Costmap3dLayerOutput>();
-    static_output_layer->setHandler(boost::bind(&Costmap3DOFNode::cbUpdateStatic, this, _1, _2));
+    auto static_output_layer = costmap_->addLayer<costmap_cspace::Costmap3dStaticLayerOutput>();
+    static_output_layer->setHandler(boost::bind(&Costmap3DOFNode::cbUpdateStatic, this, _1));
 
     sub_map_ = nh_.subscribe<nav_msgs::OccupancyGrid>(
         "map", 1,
@@ -370,8 +365,8 @@ public:
           boost::bind(&Costmap3DOFNode::cbMapOverlay, this, _1, layer)));
     }
 
-    auto update_output_layer = costmap_->addLayer<costmap_cspace::Costmap3dLayerOutput>();
-    update_output_layer->setHandler(boost::bind(&Costmap3DOFNode::cbUpdate, this, _1, _2));
+    auto update_output_layer = costmap_->addLayer<costmap_cspace::Costmap3dUpdateLayerOutput>();
+    update_output_layer->setHandler(boost::bind(&Costmap3DOFNode::cbUpdate, this, _1));
 
     const geometry_msgs::PolygonStamped footprint_msg = footprint.toMsg();
     timer_footprint_ = nh_.createTimer(

--- a/costmap_cspace/src/costmap_3d_layers.cpp
+++ b/costmap_cspace/src/costmap_3d_layers.cpp
@@ -47,11 +47,6 @@ COSTMAP_3D_LAYER_CLASS_LOADER_REGISTER(
     Costmap3dLayerPlain);
 
 COSTMAP_3D_LAYER_CLASS_LOADER_REGISTER(
-    "Costmap3dLayerOutput",
-    costmap_cspace::Costmap3dLayerOutput,
-    Costmap3dLayerOutput);
-
-COSTMAP_3D_LAYER_CLASS_LOADER_REGISTER(
     "Costmap3dLayerStopPropagation",
     costmap_cspace::Costmap3dLayerStopPropagation,
     Costmap3dLayerStopPropagation);

--- a/costmap_cspace/test/src/test_costmap_3d.cpp
+++ b/costmap_cspace/test/src/test_costmap_3d.cpp
@@ -436,7 +436,8 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
 
   // Overlay local map
   costmap_cspace_msgs::CSpace3DUpdate::Ptr updated(new costmap_cspace_msgs::CSpace3DUpdate);
-  auto cb = [&updated](const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+  auto cb = [&updated](const costmap_cspace::CSpace3DMsg::Ptr& map,
+                       const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
   {
     updated = update;
     return true;
@@ -478,7 +479,9 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
   cm_over->setExpansion(0.0, 0.0);
   cm_over->setOverlayMode(costmap_cspace::MapOverlayMode::MAX);
   costmap_cspace_msgs::CSpace3DUpdate::Ptr updated_max(new costmap_cspace_msgs::CSpace3DUpdate);
-  auto cb_max = [&updated_max](const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+
+  auto cb_max = [&updated_max](const costmap_cspace::CSpace3DMsg::Ptr& map,
+                               const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
   {
     updated_max = update;
     return true;
@@ -670,7 +673,8 @@ TEST(Costmap3dLayerOutput, CSpaceOutOfBoundary)
 
     // Overlay local map
     costmap_cspace_msgs::CSpace3DUpdate::Ptr updated;
-    auto cb = [&updated](const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+    auto cb = [&updated](const costmap_cspace::CSpace3DMsg::Ptr& map,
+                         const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
     {
       updated = update;
       return true;
@@ -754,8 +758,9 @@ TEST(Costmap3dLayerOutput, UpdateStaticMap)
   // Overlay local map
   costmap_cspace_msgs::CSpace3DUpdate::Ptr overlay_updated;
   int overlay_received_num = 0;
-  auto cb_overlay =
-      [&overlay_updated, &overlay_received_num](const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+  auto cb_overlay = [&overlay_updated,
+                     &overlay_received_num](const costmap_cspace::CSpace3DMsg::Ptr& map,
+                                            const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
   {
     overlay_updated = update;
     ++overlay_received_num;

--- a/costmap_cspace/test/src/test_costmap_3d.cpp
+++ b/costmap_cspace/test/src/test_costmap_3d.cpp
@@ -388,7 +388,7 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
       costmap_cspace::MapOverlayMode::OVERWRITE);
   cm_over->setExpansion(0.0, 0.0);
   cm_over->setFootprint(footprint);
-  auto cm_output = cms.addLayer<costmap_cspace::Costmap3dLayerOutput>();
+  auto cm_output = cms.addLayer<costmap_cspace::Costmap3dUpdateLayerOutput>();
 
   cm_ref.setAngleResolution(4);
   cm_ref.setExpansion(0.0, 0.0);
@@ -436,9 +436,7 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
 
   // Overlay local map
   costmap_cspace_msgs::CSpace3DUpdate::Ptr updated(new costmap_cspace_msgs::CSpace3DUpdate);
-  auto cb = [&updated](
-                const costmap_cspace::CSpace3DMsg::Ptr map,
-                const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+  auto cb = [&updated](const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
   {
     updated = update;
     return true;
@@ -480,9 +478,7 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
   cm_over->setExpansion(0.0, 0.0);
   cm_over->setOverlayMode(costmap_cspace::MapOverlayMode::MAX);
   costmap_cspace_msgs::CSpace3DUpdate::Ptr updated_max(new costmap_cspace_msgs::CSpace3DUpdate);
-  auto cb_max = [&updated_max](
-                    const costmap_cspace::CSpace3DMsg::Ptr map,
-                    const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+  auto cb_max = [&updated_max](const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
   {
     updated_max = update;
     return true;
@@ -650,7 +646,7 @@ TEST(Costmap3dLayerOutput, CSpaceOutOfBoundary)
     auto cm_stop = cms.addLayer<costmap_cspace::Costmap3dLayerStopPropagation>();
     auto cm_over = cms.addLayer<costmap_cspace::Costmap3dLayerPlain>(
         costmap_cspace::MapOverlayMode::OVERWRITE);
-    auto cm_output = cms.addLayer<costmap_cspace::Costmap3dLayerOutput>();
+    auto cm_output = cms.addLayer<costmap_cspace::Costmap3dUpdateLayerOutput>();
 
     // Generate two sample maps
     nav_msgs::OccupancyGrid::Ptr map(new nav_msgs::OccupancyGrid);
@@ -674,9 +670,7 @@ TEST(Costmap3dLayerOutput, CSpaceOutOfBoundary)
 
     // Overlay local map
     costmap_cspace_msgs::CSpace3DUpdate::Ptr updated;
-    auto cb = [&updated](
-                  const costmap_cspace::CSpace3DMsg::Ptr& map,
-                  const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+    auto cb = [&updated](const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
     {
       updated = update;
       return true;

--- a/costmap_cspace/test/src/test_costmap_3d.cpp
+++ b/costmap_cspace/test/src/test_costmap_3d.cpp
@@ -436,8 +436,9 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
 
   // Overlay local map
   costmap_cspace_msgs::CSpace3DUpdate::Ptr updated(new costmap_cspace_msgs::CSpace3DUpdate);
-  auto cb = [&updated](const costmap_cspace::CSpace3DMsg::Ptr& map,
-                       const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+  auto cb = [&updated](
+                const costmap_cspace::CSpace3DMsg::Ptr& map,
+                const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
   {
     updated = update;
     return true;
@@ -480,8 +481,9 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
   cm_over->setOverlayMode(costmap_cspace::MapOverlayMode::MAX);
   costmap_cspace_msgs::CSpace3DUpdate::Ptr updated_max(new costmap_cspace_msgs::CSpace3DUpdate);
 
-  auto cb_max = [&updated_max](const costmap_cspace::CSpace3DMsg::Ptr& map,
-                               const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+  auto cb_max = [&updated_max](
+                    const costmap_cspace::CSpace3DMsg::Ptr& map,
+                    const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
   {
     updated_max = update;
     return true;
@@ -673,8 +675,9 @@ TEST(Costmap3dLayerOutput, CSpaceOutOfBoundary)
 
     // Overlay local map
     costmap_cspace_msgs::CSpace3DUpdate::Ptr updated;
-    auto cb = [&updated](const costmap_cspace::CSpace3DMsg::Ptr& map,
-                         const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+    auto cb = [&updated](
+                  const costmap_cspace::CSpace3DMsg::Ptr& map,
+                  const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
     {
       updated = update;
       return true;
@@ -747,7 +750,8 @@ TEST(Costmap3dLayerOutput, UpdateStaticMap)
   // Overlay local map
   costmap_cspace::CSpace3DMsg::Ptr static_updated;
   int static_received_num = 0;
-  auto cb_static = [&static_updated, &static_received_num](const costmap_cspace::CSpace3DMsg::Ptr& update) -> bool
+  auto cb_static = [&static_updated, &static_received_num](
+                       const costmap_cspace::CSpace3DMsg::Ptr& update) -> bool
   {
     static_updated = update;
     ++static_received_num;
@@ -758,9 +762,9 @@ TEST(Costmap3dLayerOutput, UpdateStaticMap)
   // Overlay local map
   costmap_cspace_msgs::CSpace3DUpdate::Ptr overlay_updated;
   int overlay_received_num = 0;
-  auto cb_overlay = [&overlay_updated,
-                     &overlay_received_num](const costmap_cspace::CSpace3DMsg::Ptr& map,
-                                            const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+  auto cb_overlay = [&overlay_updated, &overlay_received_num](
+                        const costmap_cspace::CSpace3DMsg::Ptr& map,
+                        const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
   {
     overlay_updated = update;
     ++overlay_received_num;

--- a/costmap_cspace/test/src/test_costmap_3d.cpp
+++ b/costmap_cspace/test/src/test_costmap_3d.cpp
@@ -663,7 +663,7 @@ TEST(Costmap3dLayerOutput, CSpaceOutOfBoundary)
     map2->info.origin.orientation.w = 1.0;
     map2->info.origin.position.x = d.input.x;
     map2->info.origin.position.y = d.input.y;
-    map2->data.resize(map->info.width * map->info.height);
+    map2->data.resize(map2->info.width * map2->info.height);
 
     // Apply base map
     cm->setBaseMap(map);
@@ -712,6 +712,95 @@ TEST(Costmap3dLayerOutput, CSpaceOutOfBoundary)
       EXPECT_FALSE(static_cast<bool>(updated)) << test_name;
     }
   }
+}
+
+TEST(Costmap3dLayerOutput, UpdateStaticMap)
+{
+  // Settings: 4 angular grids
+  costmap_cspace::Costmap3d cms(4);
+  auto cm = cms.addRootLayer<costmap_cspace::Costmap3dLayerPlain>();
+  auto cm_output_static = cms.addLayer<costmap_cspace::Costmap3dStaticLayerOutput>();
+  auto cm_stop = cms.addLayer<costmap_cspace::Costmap3dLayerStopPropagation>();
+  auto cm_over = cms.addLayer<costmap_cspace::Costmap3dLayerPlain>(
+      costmap_cspace::MapOverlayMode::OVERWRITE);
+  auto cm_output_update = cms.addLayer<costmap_cspace::Costmap3dUpdateLayerOutput>();
+
+  // Generate two sample maps
+  nav_msgs::OccupancyGrid::Ptr map(new nav_msgs::OccupancyGrid);
+  map->info.width = 4;
+  map->info.height = 4;
+  map->info.resolution = 1.0;
+  map->info.origin.orientation.w = 1.0;
+  map->data.resize(map->info.width * map->info.height);
+
+  nav_msgs::OccupancyGrid::Ptr map2(new nav_msgs::OccupancyGrid);
+  map2->info.width = 5;
+  map2->info.height = 3;
+  map2->info.resolution = 1.0;
+  map2->info.origin.orientation.w = 1.0;
+  map2->data.resize(map2->info.width * map2->info.height);
+
+  // Overlay local map
+  costmap_cspace::CSpace3DMsg::Ptr static_updated;
+  int static_received_num = 0;
+  auto cb_static = [&static_updated, &static_received_num](const costmap_cspace::CSpace3DMsg::Ptr& update) -> bool
+  {
+    static_updated = update;
+    ++static_received_num;
+    return true;
+  };
+  cm_output_static->setHandler(cb_static);
+
+  // Overlay local map
+  costmap_cspace_msgs::CSpace3DUpdate::Ptr overlay_updated;
+  int overlay_received_num = 0;
+  auto cb_overlay =
+      [&overlay_updated, &overlay_received_num](const costmap_cspace_msgs::CSpace3DUpdate::Ptr& update) -> bool
+  {
+    overlay_updated = update;
+    ++overlay_received_num;
+    return true;
+  };
+  cm_output_update->setHandler(cb_overlay);
+
+  // Apply base map
+  cm->setBaseMap(map);
+  ASSERT_TRUE(static_updated);
+  EXPECT_EQ(1, static_received_num);
+  EXPECT_EQ(0, overlay_received_num);
+  EXPECT_EQ(map->info.width, static_updated->info.width);
+  EXPECT_EQ(map->info.height, static_updated->info.height);
+
+  cm->setBaseMap(map2);
+  ASSERT_TRUE(static_updated);
+  EXPECT_EQ(2, static_received_num);
+  EXPECT_EQ(0, overlay_received_num);
+  EXPECT_EQ(map2->info.width, static_updated->info.width);
+  EXPECT_EQ(map2->info.height, static_updated->info.height);
+
+  nav_msgs::OccupancyGrid::Ptr map3(new nav_msgs::OccupancyGrid);
+  map3->info.width = 2;
+  map3->info.height = 2;
+  map3->info.resolution = 1.0;
+  map3->info.origin.orientation.w = 1.0;
+  map3->info.origin.position.x = 0;
+  map3->info.origin.position.y = 0;
+  map3->data.resize(map3->info.width * map3->info.height);
+
+  cm_over->processMapOverlay(map3);
+  EXPECT_EQ(2, static_received_num);
+  EXPECT_EQ(1, overlay_received_num);
+  ASSERT_TRUE(overlay_updated);
+  EXPECT_EQ(map2->info.width, overlay_updated->width);
+  EXPECT_EQ(map2->info.height, overlay_updated->height);
+  overlay_updated.reset();
+
+  cm_over->processMapOverlay(map3);
+  EXPECT_EQ(2, static_received_num);
+  EXPECT_EQ(2, overlay_received_num);
+  ASSERT_TRUE(overlay_updated);
+  EXPECT_EQ(map3->info.width, overlay_updated->width);
+  EXPECT_EQ(map3->info.height, overlay_updated->height);
 }
 
 TEST(Costmap3dLayerFootprint, CSpaceKeepUnknown)


### PR DESCRIPTION
This PR divides Costmap3dLayerOutput into Costmap3dStaticLayerOutput and Costmap3dUpdateLayerOutput.
This change can omit unnecessary generation of costmap_cspace_msgs::CSpace3DUpdate when static map is updated.
