### PR TITLE
Fix Costmap3dLayerPlain when its parent is not plain

### DIFF
--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/plain.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/plain.h
@@ -63,21 +63,6 @@ public:
         static_cast<double>(config["linear_expand"]),
         static_cast<double>(config["linear_spread"]));
   }
-
-protected:
-  void generateCSpace(
-      CSpace3DMsg::Ptr map,
-      const nav_msgs::OccupancyGrid::ConstPtr& msg,
-      const UpdatedRegion& region) final
-  {
-    ROS_ASSERT(ang_grid_ > 0);
-    clearTravelableArea(map, msg);
-    generateSpecifiedCSpace(map, msg, 0);
-    for (size_t i = 1; i < map->info.angle; ++i)
-    {
-      CSpace3DMsg::copyCells(*map, 0, 0, i, *map, 0, 0, 0, map->info.width * map->info.height);
-    }
-  }
 };
 }  // namespace costmap_cspace
 


### PR DESCRIPTION
The overloaded `Costmap3dLayerPlain::generateCSpace` works correctly only when the maps of its parent layer are same for all angles.
This PR removes it and use the original method.