### PR TITLE
planner_cspace: fix pose duplication on path interpolation

### DIFF
--- a/planner_cspace/src/path_interpolator.cpp
+++ b/planner_cspace/src/path_interpolator.cpp
@@ -70,7 +70,7 @@ std::list<CyclicVecFloat<3, 2>> PathInterpolator::interpolate(
       }
       else if (d[2] == 0 || ds.sqlen() > local_range * local_range)
       {
-        for (float i = 0; i < 1.0; i += inter)
+        for (float i = 0; i < 1.0 - inter / 2; i += inter)
         {
           const float x2 = p_prev[0] * (1 - i) + p[0] * i;
           const float y2 = p_prev[1] * (1 - i) + p[1] * i;
@@ -92,7 +92,7 @@ std::list<CyclicVecFloat<3, 2>> PathInterpolator::interpolate(
         const float cx_prev = p_prev[0] + r1 * cosf(yawf_prev + M_PI / 2);
         const float cy_prev = p_prev[1] + r1 * sinf(yawf_prev + M_PI / 2);
 
-        for (float i = 0; i < 1.0; i += inter)
+        for (float i = 0; i < 1.0 - inter / 2; i += inter)
         {
           const float r = r1 * (1.0 - i) + r2 * i;
           const float cx2 = cx_prev * (1.0 - i) + cx * i;

--- a/planner_cspace/test/CMakeLists.txt
+++ b/planner_cspace/test/CMakeLists.txt
@@ -48,6 +48,13 @@ catkin_add_gtest(test_motion_primitive_builder
 )
 target_link_libraries(test_motion_primitive_builder ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+catkin_add_gtest(test_path_interpolator
+  src/test_path_interpolator.cpp
+  ../src/path_interpolator.cpp
+  ../src/rotation_cache.cpp
+)
+target_link_libraries(test_path_interpolator ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 add_rostest_gtest(test_debug_outputs
   test/debug_outputs_rostest.test
   src/test_debug_outputs.cpp

--- a/planner_cspace/test/src/test_path_interpolator.cpp
+++ b/planner_cspace/test/src/test_path_interpolator.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022, the neonavigation authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <list>
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <costmap_cspace_msgs/MapMetaData3D.h>
+
+#include <planner_cspace/cyclic_vec.h>
+#include <planner_cspace/planner_3d/path_interpolator.h>
+#include <planner_cspace/planner_3d/grid_metric_converter.h>
+
+namespace planner_cspace
+{
+namespace planner_3d
+{
+TEST(PathInterpolator, DuplicatedPose)
+{
+  PathInterpolator pi;
+  pi.reset(4.0, 5);
+  const std::list<CyclicVecInt<3, 2>> in = {
+      CyclicVecInt<3, 2>(0, 0, 0),
+      CyclicVecInt<3, 2>(1, 0, 0),
+      CyclicVecInt<3, 2>(2, 0, 0),
+  };
+  const std::list<CyclicVecFloat<3, 2>> out = pi.interpolate(in, 0.4999999, 0);
+
+  costmap_cspace_msgs::MapMetaData3D map_info;
+  map_info.linear_resolution = 0.1;
+  map_info.angular_resolution = M_PI / 2;
+  map_info.origin.position.x = -100.5;
+  map_info.origin.position.y = -200.5;
+
+  CyclicVecFloat<3, 2> m_prev;
+  for (auto it = out.begin(); it != out.end(); ++it)
+  {
+    CyclicVecFloat<3, 2> m;
+    // Introduce quantization error
+    grid_metric_converter::grid2Metric<float>(
+        map_info,
+        (*it)[0], (*it)[1], (*it)[2],
+        m[0], m[1], m[2]);
+
+    ASSERT_NE(m_prev, m);
+    m_prev = m;
+  }
+}
+}  // namespace planner_3d
+}  // namespace planner_cspace
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/planner_cspace/test/src/test_path_interpolator.cpp
+++ b/planner_cspace/test/src/test_path_interpolator.cpp
@@ -28,7 +28,6 @@
  */
 
 #include <list>
-#include <iostream>
 
 #include <gtest/gtest.h>
 
@@ -89,13 +88,14 @@ TEST(PathInterpolator, DuplicatedPose)
   map_info.origin.position.y = -200.5;
 
   CyclicVecFloat<3, 2> m_prev;
-  for (auto it = out.begin(); it != out.end(); ++it)
+  for (const auto& g : out)
   {
     CyclicVecFloat<3, 2> m;
+
     // Introduce quantization error
     grid_metric_converter::grid2Metric<float>(
         map_info,
-        (*it)[0], (*it)[1], (*it)[2],
+        g[0], g[1], g[2],
         m[0], m[1], m[2]);
 
     ASSERT_NE(m_prev, m);

--- a/planner_cspace/test/src/test_path_interpolator.cpp
+++ b/planner_cspace/test/src/test_path_interpolator.cpp
@@ -74,11 +74,12 @@ TEST(PathInterpolator, DuplicatedPose)
 {
   PathInterpolator pi;
   pi.reset(4.0, 5);
-  const std::list<CyclicVecInt<3, 2>> in = {
-      CyclicVecInt<3, 2>(0, 0, 0),
-      CyclicVecInt<3, 2>(1, 0, 0),
-      CyclicVecInt<3, 2>(2, 0, 0),
-  };
+  const std::list<CyclicVecInt<3, 2>> in =
+      {
+          CyclicVecInt<3, 2>(0, 0, 0),
+          CyclicVecInt<3, 2>(1, 0, 0),
+          CyclicVecInt<3, 2>(2, 0, 0),
+      };
   const std::list<CyclicVecFloat<3, 2>> out = pi.interpolate(in, 0.4999999, 0);
 
   costmap_cspace_msgs::MapMetaData3D map_info;

--- a/planner_cspace/test/src/test_path_interpolator.cpp
+++ b/planner_cspace/test/src/test_path_interpolator.cpp
@@ -42,6 +42,34 @@ namespace planner_cspace
 {
 namespace planner_3d
 {
+TEST(PathInterpolator, SimpleStraight)
+{
+  PathInterpolator pi;
+  pi.reset(4.0, 5);
+  const std::list<CyclicVecInt<3, 2>> in =
+      {
+          CyclicVecInt<3, 2>(0, 0, 0),
+          CyclicVecInt<3, 2>(1, 0, 0),
+          CyclicVecInt<3, 2>(2, 0, 0),
+      };
+  const std::list<CyclicVecFloat<3, 2>> out = pi.interpolate(in, 0.25, 0);
+
+  const std::list<CyclicVecFloat<3, 2>> expected =
+      {
+          CyclicVecFloat<3, 2>(0.00f, 0.f, 0.f),
+          CyclicVecFloat<3, 2>(0.25f, 0.f, 0.f),
+          CyclicVecFloat<3, 2>(0.50f, 0.f, 0.f),
+          CyclicVecFloat<3, 2>(0.75f, 0.f, 0.f),
+          CyclicVecFloat<3, 2>(1.00f, 0.f, 0.f),
+          CyclicVecFloat<3, 2>(1.25f, 0.f, 0.f),
+          CyclicVecFloat<3, 2>(1.50f, 0.f, 0.f),
+          CyclicVecFloat<3, 2>(1.75f, 0.f, 0.f),
+          CyclicVecFloat<3, 2>(2.00f, 0.f, 0.f),
+      };
+
+  ASSERT_EQ(expected, out);
+}
+
 TEST(PathInterpolator, DuplicatedPose)
 {
   PathInterpolator pi;


### PR DESCRIPTION
Output path might contain duplicated poses due to interpolation logic and quantization error.