### PR TITLE
safety_limiter: make sure to keep margin from obstacles

### DIFF
--- a/safety_limiter/src/safety_limiter.cpp
+++ b/safety_limiter/src/safety_limiter.cpp
@@ -489,8 +489,8 @@ protected:
         {
           // The robot is already in collision.
           // Allow movement under d_escape_ and yaw_escape_
-          d_escape_remain += d_escape_;
-          yaw_escape_remain += yaw_escape_;
+          d_escape_remain = d_escape_;
+          yaw_escape_remain = yaw_escape_;
           has_collision_at_now_ = true;
         }
         if (d_escape_remain <= 0 || yaw_escape_remain <= 0)

--- a/safety_limiter/src/safety_limiter.cpp
+++ b/safety_limiter/src/safety_limiter.cpp
@@ -487,8 +487,8 @@ protected:
         {
           // The robot is already in collision.
           // Allow movement under d_escape_ and yaw_escape_
-          d_escape_remain = d_escape_;
-          yaw_escape_remain = yaw_escape_;
+          d_escape_remain += d_escape_;
+          yaw_escape_remain += yaw_escape_;
           has_collision_at_now_ = true;
         }
         if (d_escape_remain <= 0 || yaw_escape_remain <= 0)

--- a/safety_limiter/src/safety_limiter.cpp
+++ b/safety_limiter/src/safety_limiter.cpp
@@ -483,6 +483,8 @@ protected:
       }
       if (colliding)
       {
+        d_col -= linear_vel * dt_;
+        yaw_col -= twist_.angular.z * dt_;
         if (t == 0)
         {
           // The robot is already in collision.

--- a/safety_limiter/src/safety_limiter.cpp
+++ b/safety_limiter/src/safety_limiter.cpp
@@ -483,8 +483,6 @@ protected:
       }
       if (colliding)
       {
-        d_col -= linear_vel * dt_;
-        yaw_col -= twist_.angular.z * dt_;
         if (t == 0)
         {
           // The robot is already in collision.

--- a/safety_limiter/src/safety_limiter.cpp
+++ b/safety_limiter/src/safety_limiter.cpp
@@ -478,8 +478,8 @@ protected:
           pos.z = p.z;
           col_points.points.push_back(pos);
           colliding = true;
-          d_col -= linear_vel;
-          yaw_col -= twist_.angular.z;
+          d_col -= linear_vel * dt_;
+          yaw_col -= twist_.angular.z * dt_;
           break;
         }
       }

--- a/safety_limiter/src/safety_limiter.cpp
+++ b/safety_limiter/src/safety_limiter.cpp
@@ -478,6 +478,8 @@ protected:
           pos.z = p.z;
           col_points.points.push_back(pos);
           colliding = true;
+          d_col -= linear_vel;
+          yaw_col -= twist_.angular.z;
           break;
         }
       }

--- a/safety_limiter/src/safety_limiter.cpp
+++ b/safety_limiter/src/safety_limiter.cpp
@@ -478,13 +478,13 @@ protected:
           pos.z = p.z;
           col_points.points.push_back(pos);
           colliding = true;
-          d_col -= linear_vel * dt_;
-          yaw_col -= twist_.angular.z * dt_;
           break;
         }
       }
       if (colliding)
       {
+        d_col -= linear_vel * dt_;
+        yaw_col -= twist_.angular.z * dt_;
         if (t == 0)
         {
           // The robot is already in collision.

--- a/safety_limiter/test/test/safety_limiter2_rostest.test
+++ b/safety_limiter/test/test/safety_limiter2_rostest.test
@@ -11,12 +11,12 @@
     <param name="watchdog_interval" value="0.2" />
     <param name="cloud_timeout" value="0.2" />
     <param name="freq" value="15.0" />
-    <param name="dt" value="0.01" />
+    <param name="dt" value="0.05" />
     <param name="lin_acc" value="1.0" />
     <param name="lin_vel" value="2.0" />
     <param name="ang_acc" value="1.57" />
     <param name="ang_vel" value="3.14" />
-    <param name="d_margin" value="0.2" />
+    <param name="d_margin" value="0.05" />
     <param name="yaw_margin" value="0.0" />
     <param name="z_range_min" value="-100.0" />
     <param name="z_range_max" value="100.0" />


### PR DESCRIPTION
If (`twist_` * `dt_`) exceeds `*_margin_`, the robot may not be able to stop further from the collision point than `*_margin_`. I think that this is because `*_col_` is the "collision position", but this should be a "one step away from collision position".

In this PR,
- `twist_` * `dt_` is subtracted from `*_col` when `colliding==true`.
- Acceleration is considered in `test_safety_limiter2`.
- Parameters for the test are adjusted.
  - With these parameters, the `master` (sometimes) fails when `vel` == -0.8 or 0.8 in the test.


Failure case with `master` on my local environment.
```
[ROSTEST]-----------------------------------------------------------------------

[safety_limiter.rosunit-test_safety_limiter2/SafetyLimitLinearSimpleSimulationWithMargin][FAILURE]
/home/ktakahashi/catkin_ws/src/simulation-stack/neonavigation/safety_limiter/test/src/test_safety_limiter2.cpp:94
Expected: (-0.95) < (x), actual: -0.95 vs -0.950876
--------------------------------------------------------------------------------


[safety_limiter.rosunit-test_safety_limiter2/SafetyLimitLinearSimpleSimulationWithMargin][FAILURE]
/home/ktakahashi/catkin_ws/src/simulation-stack/neonavigation/safety_limiter/test/src/test_safety_limiter2.cpp:89
Expected: (0.95) > (x), actual: 0.95 vs 0.950876
--------------------------------------------------------------------------------


SUMMARY
 * RESULT: FAIL
 * TESTS: 1
 * ERRORS: 0
 * FAILURES: 1
```