### PR TITLE
safety_limiter: fix flaky simulation tests

### DIFF
--- a/safety_limiter/test/src/test_safety_limiter.cpp
+++ b/safety_limiter/test/src/test_safety_limiter.cpp
@@ -513,7 +513,7 @@ TEST_F(SafetyLimiterTest, NoCollision)
 
 TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulation)
 {
-  const float dt = 0.01;
+  const float dt = 0.02;
   ros::Rate wait(1.0 / dt);
 
   const float velocities[] = {-0.8, -0.5, 0.5, 0.8};
@@ -522,7 +522,7 @@ TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulation)
     float x = 0;
     bool stopped = false;
 
-    int count_after_stop = 3;
+    int count_after_stop = 10;
     for (float t = 0; t < 10.0 && ros::ok() && count_after_stop > 0; t += dt)
     {
       if (vel > 0)

--- a/safety_limiter/test/src/test_safety_limiter.cpp
+++ b/safety_limiter/test/src/test_safety_limiter.cpp
@@ -520,9 +520,10 @@ TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulation)
   for (const float vel : velocities)
   {
     float x = 0;
-    bool stop = false;
+    bool stopped = false;
 
-    for (int i = 0; i < std::lround(10.0 / dt) && ros::ok() && !stop; ++i)
+    int count_after_stop = 3;
+    for (float t = 0; t < 10.0 && ros::ok() && count_after_stop > 0; t += dt)
     {
       if (vel > 0)
         publishSinglePointPointcloud2(1.0 - x, 0, 0, "base_link", ros::Time::now());
@@ -538,9 +539,14 @@ TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulation)
       if (cmd_vel_)
       {
         if (std::abs(cmd_vel_->linear.x) < 1e-4 && x > 0.5)
-          stop = true;
-
+        {
+          stopped = true;
+        }
         x += dt * cmd_vel_->linear.x;
+      }
+      if (stopped)
+      {
+        count_after_stop--;
       }
     }
     if (vel > 0)

--- a/safety_limiter/test/src/test_safety_limiter.cpp
+++ b/safety_limiter/test/src/test_safety_limiter.cpp
@@ -513,7 +513,7 @@ TEST_F(SafetyLimiterTest, NoCollision)
 
 TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulation)
 {
-  const float dt = 0.02;
+  const float dt = 0.01;
   ros::Rate wait(1.0 / dt);
 
   const float velocities[] = {-0.8, -0.5, 0.5, 0.8};

--- a/safety_limiter/test/src/test_safety_limiter2.cpp
+++ b/safety_limiter/test/src/test_safety_limiter2.cpp
@@ -42,7 +42,7 @@
 
 TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulationWithMargin)
 {
-  const float dt = 0.02;
+  const float dt = 0.01;
   const double ax = 2.0;  // [m/ss]
   double v = 0.0;         // [m/s]
   ros::Rate wait(1.0 / dt);

--- a/safety_limiter/test/src/test_safety_limiter2.cpp
+++ b/safety_limiter/test/src/test_safety_limiter2.cpp
@@ -91,13 +91,17 @@ TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulationWithMargin)
     // margin is set to 0.2
     if (vel > 0)
     {
-      EXPECT_GT(0.95, x);  // Collision point - margin
-      EXPECT_LT(0.90, x);  // Collision point - margin * 2
+      EXPECT_GT(0.95, x)
+          << "vel: " << vel;  // Collision point - margin
+      EXPECT_LT(0.90, x)
+          << "vel: " << vel;  // Collision point - margin * 2
     }
     else
     {
-      EXPECT_LT(-0.95, x);  // Collision point + margin
-      EXPECT_GT(-0.90, x);  // Collision point + margin * 2
+      EXPECT_LT(-0.95, x)
+          << "vel: " << vel;  // Collision point + margin
+      EXPECT_GT(-0.90, x)
+          << "vel: " << vel;  // Collision point + margin * 2
     }
     sub_cmd_vel.shutdown();
   }

--- a/safety_limiter/test/src/test_safety_limiter2.cpp
+++ b/safety_limiter/test/src/test_safety_limiter2.cpp
@@ -44,19 +44,19 @@ TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulationWithMargin)
 {
   const float dt = 0.02;
   const double ax = 2.0;  // [m/ss]
-  double v = 0.0;   // [m/s]
+  double v = 0.0;         // [m/s]
   ros::Rate wait(1.0 / dt);
 
   const float velocities[] = {-0.8, -0.4, 0.4, 0.8};
   for (const float vel : velocities)
   {
     float x = 0;
-    bool stop = false;
+    bool stopped = false;
     const boost::function<void(const geometry_msgs::Twist::ConstPtr&)> cb_cmd_vel =
-        [dt, ax, &x, &v, &stop](const geometry_msgs::Twist::ConstPtr& msg) -> void
+        [dt, ax, &x, &v, &stopped](const geometry_msgs::Twist::ConstPtr& msg) -> void
     {
       if (std::abs(v) < 1e-4 && std::abs(x) > 0.5)
-        stop = true;
+        stopped = true;
 
       if (msg->linear.x >= v)
       {
@@ -70,7 +70,8 @@ TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulationWithMargin)
     };
     ros::Subscriber sub_cmd_vel = nh_.subscribe("cmd_vel", 1, cb_cmd_vel);
 
-    for (int i = 0; i < std::lround(10.0 / dt) && ros::ok() && !stop; ++i)
+    int count_after_stop = 3;
+    for (float t = 0; t < 10.0 && ros::ok() && count_after_stop > 0; t += dt)
     {
       if (vel > 0)
         publishSinglePointPointcloud2(1.0 - x, 0, 0, "base_link", ros::Time::now());
@@ -82,6 +83,10 @@ TEST_F(SafetyLimiterTest, SafetyLimitLinearSimpleSimulationWithMargin)
 
       wait.sleep();
       ros::spinOnce();
+      if (stopped)
+      {
+        count_after_stop--;
+      }
     }
     // margin is set to 0.2
     if (vel > 0)


### PR DESCRIPTION
https://github.com/at-wat/neonavigation/issues/655#issuecomment-1366472064

Continue simulation for a bit after the speed gets small.