### PR TITLE
planner_cspace: fix uninitialized variables in DistanceMap

### DIFF
--- a/planner_cspace/include/planner_cspace/planner_3d/distance_map.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/distance_map.h
@@ -120,7 +120,6 @@ public:
   }
 
 protected:
-  bool initialized_;
   Astar::Gridmap<float> g_;
   Params p_;
   CostCoeff cc_;

--- a/planner_cspace/include/planner_cspace/planner_3d/distance_map.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/distance_map.h
@@ -120,6 +120,7 @@ public:
   }
 
 protected:
+  bool initialized_;
   Astar::Gridmap<float> g_;
   Params p_;
   CostCoeff cc_;

--- a/planner_cspace/src/distance_map.cpp
+++ b/planner_cspace/src/distance_map.cpp
@@ -168,7 +168,8 @@ void DistanceMap::fillCostmap(
 DistanceMap::DistanceMap(
     const BlockMemGridmapBase<char, 3, 2>& cm_rough,
     const CostmapBBF& bbf_costmap)
-  : cm_rough_(cm_rough)
+  : initialized_(false)
+  , cm_rough_(cm_rough)
   , bbf_costmap_(bbf_costmap)
 {
 }
@@ -181,13 +182,15 @@ void DistanceMap::setParams(const CostCoeff& cc, const int num_cost_estim_task)
 
 void DistanceMap::init(const GridAstarModel3D::Ptr model, const Params& p)
 {
-  if (p.size[0] != p_.size[0] || p.size[1] != p_.size[1])
+  if (!initialized_ || p.size[0] != p_.size[0] || p.size[1] != p_.size[1])
   {
     // Typical open/erase queue size is be approximated by perimeter of the map
     pq_open_.reserve((p.size[0] + p.size[1]) * 2);
     pq_erase_.reserve((p.size[0] + p.size[1]) * 2);
 
     g_.reset(Astar::Vec(p.size[0], p.size[1], 1));
+    g_.clear(0);
+    initialized_ = true;
   }
   p_ = p;
   search_diffs_.clear();

--- a/planner_cspace/src/distance_map.cpp
+++ b/planner_cspace/src/distance_map.cpp
@@ -168,8 +168,7 @@ void DistanceMap::fillCostmap(
 DistanceMap::DistanceMap(
     const BlockMemGridmapBase<char, 3, 2>& cm_rough,
     const CostmapBBF& bbf_costmap)
-  : initialized_(false)
-  , cm_rough_(cm_rough)
+  : cm_rough_(cm_rough)
   , bbf_costmap_(bbf_costmap)
 {
 }
@@ -182,7 +181,7 @@ void DistanceMap::setParams(const CostCoeff& cc, const int num_cost_estim_task)
 
 void DistanceMap::init(const GridAstarModel3D::Ptr model, const Params& p)
 {
-  if (!initialized_ || p.size[0] != p_.size[0] || p.size[1] != p_.size[1])
+  if (p.size[0] != p_.size[0] || p.size[1] != p_.size[1])
   {
     // Typical open/erase queue size is be approximated by perimeter of the map
     pq_open_.reserve((p.size[0] + p.size[1]) * 2);
@@ -190,7 +189,6 @@ void DistanceMap::init(const GridAstarModel3D::Ptr model, const Params& p)
 
     g_.reset(Astar::Vec(p.size[0], p.size[1], 1));
     g_.clear(0);
-    initialized_ = true;
   }
   p_ = p;
   search_diffs_.clear();

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -972,6 +972,8 @@ protected:
     hyst_updated_cells_.clear();
     has_hysteresis_map_ = false;
 
+    cm_updates_.clear(0);
+
     has_map_ = true;
 
     cm_rough_base_ = cm_rough_;

--- a/planner_cspace/test/src/test_distance_map.cpp
+++ b/planner_cspace/test/src/test_distance_map.cpp
@@ -120,12 +120,10 @@ protected:
     map_info.linear_resolution = 1.0;
     map_info.angular_resolution = M_PI * 2 / angle_;
 
-    CostCoeff cc =
-        {
-            .weight_costmap_ = 1.0f,
-            .weight_remembered_ = 0.0f,
-            .angle_resolution_aspect_ = 2.0f / tanf(map_info.angular_resolution),
-        };
+    CostCoeff cc;
+    cc.weight_costmap_ = 1.0f;
+    cc.weight_remembered_ = 0.0f;
+    cc.angle_resolution_aspect_ = 2.0f / tanf(map_info.angular_resolution);
     dm_.setParams(cc, 64 * 2);
 
     const Astar::Vec size3d(w_, h_, angle_);
@@ -345,12 +343,10 @@ protected:
     map_info.linear_resolution = 1.0;
     map_info.angular_resolution = M_PI * 2 / angle_;
 
-    CostCoeff cc =
-        {
-            .weight_costmap_ = 1.0f,
-            .weight_remembered_ = 0.0f,
-            .angle_resolution_aspect_ = 2.0f / tanf(map_info.angular_resolution),
-        };
+    CostCoeff cc;
+    cc.weight_costmap_ = 1.0f;
+    cc.weight_remembered_ = 0.0f;
+    cc.angle_resolution_aspect_ = 2.0f / tanf(map_info.angular_resolution);
     omp_set_num_threads(1);
     dm_.setParams(cc, 1);
 

--- a/planner_cspace/test/src/test_distance_map.cpp
+++ b/planner_cspace/test/src/test_distance_map.cpp
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cmath>
 #include <limits>
 #include <string>
 #include <vector>
@@ -110,10 +111,7 @@ protected:
   {
     const int range = 4;
     const int local_range = 10;
-    CostCoeff cc;
-    cc.weight_costmap_ = 1.0f;
     omp_set_num_threads(2);
-    dm_.setParams(cc, 64 * 2);
 
     costmap_cspace_msgs::MapMetaData3D map_info;
     map_info.width = w_;
@@ -121,6 +119,14 @@ protected:
     map_info.angle = angle_;
     map_info.linear_resolution = 1.0;
     map_info.angular_resolution = M_PI * 2 / angle_;
+
+    CostCoeff cc =
+        {
+            .weight_costmap_ = 1.0f,
+            .weight_remembered_ = 0.0f,
+            .angle_resolution_aspect_ = 2.0f / tanf(map_info.angular_resolution),
+        };
+    dm_.setParams(cc, 64 * 2);
 
     const Astar::Vec size3d(w_, h_, angle_);
     const Astar::Vec size2d(w_, h_, 1);
@@ -137,6 +143,11 @@ protected:
     cm_hyst.reset(size3d);
     cm_rough_.reset(size2d);
     bbf_costmap_.reset(size2d);
+
+    cm.clear(0);
+    cm_hyst.clear(0);
+    cm_rough_.clear(0);
+    bbf_costmap_.clear();
 
     const DistanceMap::Params dmp =
         {
@@ -327,17 +338,21 @@ protected:
     : ec_(0.5f, 0.5f, 0.2f)
     , dm_(cm_rough_, bbf_costmap_)
   {
-    CostCoeff cc;
-    cc.weight_costmap_ = 1.0f;
-    omp_set_num_threads(1);
-    dm_.setParams(cc, 1);
-
     costmap_cspace_msgs::MapMetaData3D map_info;
     map_info.width = w_;
     map_info.height = h_;
     map_info.angle = angle_;
     map_info.linear_resolution = 1.0;
     map_info.angular_resolution = M_PI * 2 / angle_;
+
+    CostCoeff cc =
+        {
+            .weight_costmap_ = 1.0f,
+            .weight_remembered_ = 0.0f,
+            .angle_resolution_aspect_ = 2.0f / tanf(map_info.angular_resolution),
+        };
+    omp_set_num_threads(1);
+    dm_.setParams(cc, 1);
 
     const Astar::Vec size3d(w_, h_, angle_);
     const Astar::Vec size2d(w_, h_, 1);
@@ -354,7 +369,10 @@ protected:
     cm_hyst.reset(size3d);
     cm_rough_.reset(size2d);
     bbf_costmap_.reset(size2d);
+    cm.clear(0);
+    cm_hyst.clear(0);
     cm_rough_.clear(0);
+    bbf_costmap_.clear();
 
     const DistanceMap::Params dmp =
         {


### PR DESCRIPTION
Fix uninitialized variables detected by `valgrind` on gtest executables.