### PR TITLE
costmap_cspace: added update_chain_entry bool arguement to processMapOverlay function

### DIFF
--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/base.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/base.h
@@ -372,7 +372,7 @@ public:
     }
     else
     {
-      ROS_INFO("update_chain_entry execution has been avoided.");
+      ROS_DEBUG("update_chain_entry execution has been avoided.");
     }
   }
   CSpace3DMsg::Ptr getMap()

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/base.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/base.h
@@ -10,8 +10,8 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the copyright holder nor the names of its 
- *       contributors may be used to endorse or promote products derived from 
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -346,7 +346,7 @@ public:
             0, 0, 0, map_->info.width, map_->info.height, map_->info.angle,
             base_map->header.stamp));
   }
-  void processMapOverlay(const nav_msgs::OccupancyGrid::ConstPtr& msg)
+  void processMapOverlay(const nav_msgs::OccupancyGrid::ConstPtr& msg, const bool update_chain_entry)
   {
     ROS_ASSERT(!root_);
     ROS_ASSERT(ang_grid_ > 0);
@@ -365,7 +365,15 @@ public:
     map_updated_ = msg;
 
     region_ = UpdatedRegion(ox, oy, 0, w, h, map_->info.angle, msg->header.stamp);
-    updateChainEntry(UpdatedRegion(ox, oy, 0, w, h, map_->info.angle, msg->header.stamp));
+
+    if (update_chain_entry)
+    {
+      updateChainEntry(UpdatedRegion(ox, oy, 0, w, h, map_->info.angle, msg->header.stamp));
+    }
+    else
+    {
+      ROS_INFO("update_chain_entry execution has been avoided.");
+    }
   }
   CSpace3DMsg::Ptr getMap()
   {

--- a/costmap_cspace/src/costmap_3d.cpp
+++ b/costmap_cspace/src/costmap_3d.cpp
@@ -99,7 +99,7 @@ protected:
       return;
     }
 
-    map->processMapOverlay(msg, 1);
+    map->processMapOverlay(msg, true);
     ROS_DEBUG("C-Space costmap updated");
   }
   bool cbUpdateStatic(

--- a/costmap_cspace/src/costmap_3d.cpp
+++ b/costmap_cspace/src/costmap_3d.cpp
@@ -10,8 +10,8 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the copyright holder nor the names of its 
- *       contributors may be used to endorse or promote products derived from 
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -99,7 +99,7 @@ protected:
       return;
     }
 
-    map->processMapOverlay(msg);
+    map->processMapOverlay(msg, 1);
     ROS_DEBUG("C-Space costmap updated");
   }
   bool cbUpdateStatic(

--- a/costmap_cspace/test/src/test_costmap_3d.cpp
+++ b/costmap_cspace/test/src/test_costmap_3d.cpp
@@ -444,7 +444,7 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
     return true;
   };
   cm_output->setHandler(cb);
-  cm_over->processMapOverlay(map2, 1);
+  cm_over->processMapOverlay(map2, true);
 
   // In this case, updated map must have same size as the base map. Check it.
   ASSERT_EQ(0u, updated->x);
@@ -489,7 +489,7 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
     return true;
   };
   cm_output->setHandler(cb_max);
-  cm_over->processMapOverlay(map2, 1);
+  cm_over->processMapOverlay(map2, true);
 
   ASSERT_EQ(0u, updated_max->x);
   ASSERT_EQ(0u, updated_max->y);
@@ -557,7 +557,7 @@ TEST(Costmap3dLayerFootprint, CSpaceOverlayMove)
     {
       map2->info.origin.position.x = map2->info.resolution * xp;
       map2->info.origin.position.y = map2->info.resolution * yp;
-      cm_over->processMapOverlay(map2, 1);
+      cm_over->processMapOverlay(map2, true);
       for (int k = 0; k < cm_over->getAngularGrid(); ++k)
       {
         const size_t i_center = map->info.width / 2;
@@ -684,7 +684,7 @@ TEST(Costmap3dLayerOutput, CSpaceOutOfBoundary)
     };
     cm_output->setHandler(cb);
     // First pass of the processing contains parent layer updates
-    cm_over->processMapOverlay(map2, 1);
+    cm_over->processMapOverlay(map2, true);
 
     if (d.valid)
     {
@@ -702,7 +702,7 @@ TEST(Costmap3dLayerOutput, CSpaceOutOfBoundary)
     }
 
     // Second pass has only local updates
-    cm_over->processMapOverlay(map2, 1);
+    cm_over->processMapOverlay(map2, true);
 
     if (d.valid)
     {
@@ -796,7 +796,7 @@ TEST(Costmap3dLayerOutput, UpdateStaticMap)
   map3->info.origin.position.y = 0;
   map3->data.resize(map3->info.width * map3->info.height);
 
-  cm_over->processMapOverlay(map3, 1);
+  cm_over->processMapOverlay(map3, true);
   EXPECT_EQ(2, static_received_num);
   EXPECT_EQ(1, overlay_received_num);
   ASSERT_TRUE(overlay_updated);
@@ -804,7 +804,7 @@ TEST(Costmap3dLayerOutput, UpdateStaticMap)
   EXPECT_EQ(map2->info.height, overlay_updated->height);
   overlay_updated.reset();
 
-  cm_over->processMapOverlay(map3, 1);
+  cm_over->processMapOverlay(map3, true);
   EXPECT_EQ(2, static_received_num);
   EXPECT_EQ(2, overlay_received_num);
   ASSERT_TRUE(overlay_updated);
@@ -855,7 +855,7 @@ TEST(Costmap3dLayerFootprint, CSpaceKeepUnknown)
   cm_normal->setFootprint(footprint);
   cm_normal->setKeepUnknown(false);
   cm_base1->setBaseMap(map);
-  cm_normal->processMapOverlay(map_overlay, 1);
+  cm_normal->processMapOverlay(map_overlay, true);
 
   costmap_cspace::Costmap3d cms2(4);
   auto cm_base2 = cms2.addRootLayer<costmap_cspace::Costmap3dLayerFootprint>();
@@ -867,7 +867,7 @@ TEST(Costmap3dLayerFootprint, CSpaceKeepUnknown)
   cm_keep_uknown->setFootprint(footprint);
   cm_keep_uknown->setKeepUnknown(true);
   cm_base2->setBaseMap(map);
-  cm_keep_uknown->processMapOverlay(map_overlay, 1);
+  cm_keep_uknown->processMapOverlay(map_overlay, true);
 
   const costmap_cspace::CSpace3DMsg::Ptr normal_result = cm_normal->getMapOverlay();
   const costmap_cspace::CSpace3DMsg::Ptr keep_unknown_result = cm_keep_uknown->getMapOverlay();
@@ -936,7 +936,7 @@ TEST(Costmap3dLayerFootprint, Costmap3dLayerPlain)
   cm_normal->setFootprint(footprint);
   cm_normal->setKeepUnknown(false);
   cm_base1->setBaseMap(map);
-  cm_normal->processMapOverlay(map_overlay, 1);
+  cm_normal->processMapOverlay(map_overlay, true);
 
   costmap_cspace::Costmap3d cms2(4);
   auto cm_base2 = cms2.addRootLayer<costmap_cspace::Costmap3dLayerPlain>();
@@ -946,7 +946,7 @@ TEST(Costmap3dLayerFootprint, Costmap3dLayerPlain)
   cm_plain->setExpansion(0.0, 2.0);
   cm_plain->setKeepUnknown(false);
   cm_base2->setBaseMap(map);
-  cm_plain->processMapOverlay(map_overlay, 1);
+  cm_plain->processMapOverlay(map_overlay, true);
 
   const costmap_cspace::CSpace3DMsg::Ptr normal_result = cm_normal->getMapOverlay();
   const costmap_cspace::CSpace3DMsg::Ptr plain_result = cm_plain->getMapOverlay();
@@ -998,7 +998,7 @@ TEST(Costmap3dLayerFootprint, PlainOnFootprint)
   cm->setBaseMap(map);
 
   map2->data[3 + 4 * map->info.width] = max_cost;
-  cm_over->processMapOverlay(map2, 1);
+  cm_over->processMapOverlay(map2, true);
 
   const costmap_cspace::CSpace3DMsg::Ptr static_map = cm->getMap();
   const costmap_cspace::CSpace3DMsg::Ptr overlay_map = cm_over->getMapOverlay();

--- a/costmap_cspace/test/src/test_costmap_3d.cpp
+++ b/costmap_cspace/test/src/test_costmap_3d.cpp
@@ -444,7 +444,7 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
     return true;
   };
   cm_output->setHandler(cb);
-  cm_over->processMapOverlay(map2);
+  cm_over->processMapOverlay(map2, 1);
 
   // In this case, updated map must have same size as the base map. Check it.
   ASSERT_EQ(0u, updated->x);
@@ -489,7 +489,7 @@ TEST(Costmap3dLayerFootprint, CSpaceOverwrite)
     return true;
   };
   cm_output->setHandler(cb_max);
-  cm_over->processMapOverlay(map2);
+  cm_over->processMapOverlay(map2, 1);
 
   ASSERT_EQ(0u, updated_max->x);
   ASSERT_EQ(0u, updated_max->y);
@@ -557,7 +557,7 @@ TEST(Costmap3dLayerFootprint, CSpaceOverlayMove)
     {
       map2->info.origin.position.x = map2->info.resolution * xp;
       map2->info.origin.position.y = map2->info.resolution * yp;
-      cm_over->processMapOverlay(map2);
+      cm_over->processMapOverlay(map2, 1);
       for (int k = 0; k < cm_over->getAngularGrid(); ++k)
       {
         const size_t i_center = map->info.width / 2;
@@ -684,7 +684,7 @@ TEST(Costmap3dLayerOutput, CSpaceOutOfBoundary)
     };
     cm_output->setHandler(cb);
     // First pass of the processing contains parent layer updates
-    cm_over->processMapOverlay(map2);
+    cm_over->processMapOverlay(map2, 1);
 
     if (d.valid)
     {
@@ -702,7 +702,7 @@ TEST(Costmap3dLayerOutput, CSpaceOutOfBoundary)
     }
 
     // Second pass has only local updates
-    cm_over->processMapOverlay(map2);
+    cm_over->processMapOverlay(map2, 1);
 
     if (d.valid)
     {
@@ -796,7 +796,7 @@ TEST(Costmap3dLayerOutput, UpdateStaticMap)
   map3->info.origin.position.y = 0;
   map3->data.resize(map3->info.width * map3->info.height);
 
-  cm_over->processMapOverlay(map3);
+  cm_over->processMapOverlay(map3, 1);
   EXPECT_EQ(2, static_received_num);
   EXPECT_EQ(1, overlay_received_num);
   ASSERT_TRUE(overlay_updated);
@@ -804,7 +804,7 @@ TEST(Costmap3dLayerOutput, UpdateStaticMap)
   EXPECT_EQ(map2->info.height, overlay_updated->height);
   overlay_updated.reset();
 
-  cm_over->processMapOverlay(map3);
+  cm_over->processMapOverlay(map3, 1);
   EXPECT_EQ(2, static_received_num);
   EXPECT_EQ(2, overlay_received_num);
   ASSERT_TRUE(overlay_updated);
@@ -855,7 +855,7 @@ TEST(Costmap3dLayerFootprint, CSpaceKeepUnknown)
   cm_normal->setFootprint(footprint);
   cm_normal->setKeepUnknown(false);
   cm_base1->setBaseMap(map);
-  cm_normal->processMapOverlay(map_overlay);
+  cm_normal->processMapOverlay(map_overlay, 1);
 
   costmap_cspace::Costmap3d cms2(4);
   auto cm_base2 = cms2.addRootLayer<costmap_cspace::Costmap3dLayerFootprint>();
@@ -867,7 +867,7 @@ TEST(Costmap3dLayerFootprint, CSpaceKeepUnknown)
   cm_keep_uknown->setFootprint(footprint);
   cm_keep_uknown->setKeepUnknown(true);
   cm_base2->setBaseMap(map);
-  cm_keep_uknown->processMapOverlay(map_overlay);
+  cm_keep_uknown->processMapOverlay(map_overlay, 1);
 
   const costmap_cspace::CSpace3DMsg::Ptr normal_result = cm_normal->getMapOverlay();
   const costmap_cspace::CSpace3DMsg::Ptr keep_unknown_result = cm_keep_uknown->getMapOverlay();
@@ -936,7 +936,7 @@ TEST(Costmap3dLayerFootprint, Costmap3dLayerPlain)
   cm_normal->setFootprint(footprint);
   cm_normal->setKeepUnknown(false);
   cm_base1->setBaseMap(map);
-  cm_normal->processMapOverlay(map_overlay);
+  cm_normal->processMapOverlay(map_overlay, 1);
 
   costmap_cspace::Costmap3d cms2(4);
   auto cm_base2 = cms2.addRootLayer<costmap_cspace::Costmap3dLayerPlain>();
@@ -946,7 +946,7 @@ TEST(Costmap3dLayerFootprint, Costmap3dLayerPlain)
   cm_plain->setExpansion(0.0, 2.0);
   cm_plain->setKeepUnknown(false);
   cm_base2->setBaseMap(map);
-  cm_plain->processMapOverlay(map_overlay);
+  cm_plain->processMapOverlay(map_overlay, 1);
 
   const costmap_cspace::CSpace3DMsg::Ptr normal_result = cm_normal->getMapOverlay();
   const costmap_cspace::CSpace3DMsg::Ptr plain_result = cm_plain->getMapOverlay();
@@ -998,7 +998,7 @@ TEST(Costmap3dLayerFootprint, PlainOnFootprint)
   cm->setBaseMap(map);
 
   map2->data[3 + 4 * map->info.width] = max_cost;
-  cm_over->processMapOverlay(map2);
+  cm_over->processMapOverlay(map2, 1);
 
   const costmap_cspace::CSpace3DMsg::Ptr static_map = cm->getMap();
   const costmap_cspace::CSpace3DMsg::Ptr overlay_map = cm_over->getMapOverlay();


### PR DESCRIPTION
This argument is implemented so as to be able to toggle updateChainEntry() only after all map layers have been processed within SQ Maps.