### PR TITLE
planner_cspace: fix error status handling after cost_estim_cache_ was not created

### DIFF
--- a/planner_cspace/src/patrol.cpp
+++ b/planner_cspace/src/patrol.cpp
@@ -130,43 +130,38 @@ public:
   void spin()
   {
     ros::Rate rate(10.0);
-    int cnt = 0;
     while (ros::ok())
     {
       ros::spinOnce();
       rate.sleep();
-
-      if (cnt % 10 == 0)
+      if (path_.poses.size() == 0)
       {
-        if (path_.poses.size() == 0)
-        {
-          continue;
-        }
+        continue;
+      }
 
-        if (pos_ == 0)
-        {
-          sendNextGoal();
-          continue;
-        }
+      if (pos_ == 0)
+      {
+        sendNextGoal();
+        continue;
+      }
 
-        actionlib::SimpleClientGoalState state =
-            with_tolerance_ ?
-                act_cli_tolerant_->getState() :
-                act_cli_->getState();
-        if (state == actionlib::SimpleClientGoalState::SUCCEEDED)
-        {
-          ROS_INFO("Action has been finished.");
-          sendNextGoal();
-        }
-        else if (state == actionlib::SimpleClientGoalState::ABORTED)
-        {
-          ROS_ERROR("Action has been aborted. Skipping.");
-          sendNextGoal();
-        }
-        else if (state == actionlib::SimpleClientGoalState::LOST)
-        {
-          ROS_WARN_ONCE("Action server is not ready.");
-        }
+      actionlib::SimpleClientGoalState state =
+          with_tolerance_ ?
+              act_cli_tolerant_->getState() :
+              act_cli_->getState();
+      if (state == actionlib::SimpleClientGoalState::SUCCEEDED)
+      {
+        ROS_INFO("Action has been finished.");
+        sendNextGoal();
+      }
+      else if (state == actionlib::SimpleClientGoalState::ABORTED)
+      {
+        ROS_ERROR("Action has been aborted. Skipping.");
+        sendNextGoal();
+      }
+      else if (state == actionlib::SimpleClientGoalState::LOST)
+      {
+        ROS_WARN_ONCE("Action server is not ready.");
       }
     }
   }

--- a/planner_cspace/src/patrol.cpp
+++ b/planner_cspace/src/patrol.cpp
@@ -129,41 +129,44 @@ public:
   }
   void spin()
   {
-    ros::Rate rate(1.0);
-
+    ros::Rate rate(10.0);
+    int cnt = 0;
     while (ros::ok())
     {
       ros::spinOnce();
       rate.sleep();
 
-      if (path_.poses.size() == 0)
+      if (cnt % 10 == 0)
       {
-        continue;
-      }
+        if (path_.poses.size() == 0)
+        {
+          continue;
+        }
 
-      if (pos_ == 0)
-      {
-        sendNextGoal();
-        continue;
-      }
+        if (pos_ == 0)
+        {
+          sendNextGoal();
+          continue;
+        }
 
-      actionlib::SimpleClientGoalState state =
-          with_tolerance_ ?
-              act_cli_tolerant_->getState() :
-              act_cli_->getState();
-      if (state == actionlib::SimpleClientGoalState::SUCCEEDED)
-      {
-        ROS_INFO("Action has been finished.");
-        sendNextGoal();
-      }
-      else if (state == actionlib::SimpleClientGoalState::ABORTED)
-      {
-        ROS_ERROR("Action has been aborted. Skipping.");
-        sendNextGoal();
-      }
-      else if (state == actionlib::SimpleClientGoalState::LOST)
-      {
-        ROS_WARN_ONCE("Action server is not ready.");
+        actionlib::SimpleClientGoalState state =
+            with_tolerance_ ?
+                act_cli_tolerant_->getState() :
+                act_cli_->getState();
+        if (state == actionlib::SimpleClientGoalState::SUCCEEDED)
+        {
+          ROS_INFO("Action has been finished.");
+          sendNextGoal();
+        }
+        else if (state == actionlib::SimpleClientGoalState::ABORTED)
+        {
+          ROS_ERROR("Action has been aborted. Skipping.");
+          sendNextGoal();
+        }
+        else if (state == actionlib::SimpleClientGoalState::LOST)
+        {
+          ROS_WARN_ONCE("Action server is not ready.");
+        }
       }
     }
   }

--- a/planner_cspace/src/patrol.cpp
+++ b/planner_cspace/src/patrol.cpp
@@ -130,10 +130,12 @@ public:
   void spin()
   {
     ros::Rate rate(10.0);
+
     while (ros::ok())
     {
       ros::spinOnce();
       rate.sleep();
+
       if (path_.poses.size() == 0)
       {
         continue;

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -551,6 +551,7 @@ protected:
       default:
         break;
     }
+    cnt_stuck_ = 0;
     const auto ts = boost::chrono::high_resolution_clock::now();
     cost_estim_cache_.create(s, e);
     const auto tnow = boost::chrono::high_resolution_clock::now();

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1417,6 +1417,7 @@ public:
         }
         else
         {
+          bool skip_path_planning = false;
           if (escaping_)
           {
             status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
@@ -1441,9 +1442,30 @@ public:
 
             continue;
           }
-          else if (cost_estim_cache_created_)
+          else if (!cost_estim_cache_created_)
+          {
+            skip_path_planning = true;
+            if (is_start_occupied_)
+            {
+              status_.error = planner_cspace_msgs::PlannerStatus::IN_ROCK;
+            }
+            else
+            {
+              status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
+            }
+          }
+          else
           {
             status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
+          }
+
+          if (skip_path_planning)
+          {
+            publishEmptyPath();
+            previous_path.poses.clear();
+          }
+          else
+          {
             nav_msgs::Path path;
             path.header = map_header_;
             path.header.stamp = now;
@@ -1466,19 +1488,6 @@ public:
               if (is_path_switchback)
                 sw_pos_ = path.poses[sw_index];
             }
-          }
-          else
-          {
-            if (is_start_occupied_)
-            {
-              status_.error = planner_cspace_msgs::PlannerStatus::IN_ROCK;
-            }
-            else
-            {
-              status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
-            }
-            publishEmptyPath();
-            previous_path.poses.clear();
           }
         }
       }

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1269,7 +1269,7 @@ public:
     {
       const ros::Time prev_map_update_stamp = last_costmap_;
       ros::spinOnce();
-      const bool costmap_udpated = last_costmap_ != prev_map_update_stamp;
+      const bool costmap_updated = last_costmap_ != prev_map_update_stamp;
 
       if (has_map_)
       {
@@ -1282,7 +1282,7 @@ public:
           return;
         }
 
-        if (costmap_udpated && previous_path.poses.size() > 1)
+        if (costmap_updated && previous_path.poses.size() > 1)
         {
           for (const auto& path_pose : previous_path.poses)
           {

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -153,7 +153,7 @@ protected:
   bool has_start_;
   bool has_hysteresis_map_;
   std::vector<Astar::Vec> hyst_updated_cells_;
-  bool goal_updated_;
+  bool cost_estim_cache_created_;
   bool remember_updates_;
   bool fast_map_update_;
   std::vector<Astar::Vec> search_list_;
@@ -203,6 +203,7 @@ protected:
   bool escaping_;
 
   int cnt_stuck_;
+  bool is_start_occupied_;
 
   diagnostic_updater::Updater diag_updater_;
   ros::Duration costmap_watchdog_;
@@ -409,7 +410,7 @@ protected:
       escaping_ = false;
       has_goal_ = true;
       cnt_stuck_ = 0;
-      if (!updateGoal())
+      if (!createCostEstimCache())
       {
         has_goal_ = false;
         return false;
@@ -485,7 +486,7 @@ protected:
     ROS_DEBUG("    (%d,%d,%d)", s[0], s[1], s[2]);
     return true;
   }
-  bool updateGoal(const bool goal_changed = true)
+  bool createCostEstimCache(const bool goal_changed = true)
   {
     if (!has_goal_)
       return true;
@@ -496,6 +497,9 @@ protected:
                 static_cast<int>(has_map_), static_cast<int>(has_goal_), static_cast<int>(has_start_));
       return true;
     }
+
+    cost_estim_cache_created_ = false;
+    is_start_occupied_ = false;
 
     Astar::Vec s, e;
     grid_metric_converter::metric2Grid(
@@ -527,6 +531,7 @@ protected:
       case DiscretePoseStatus::IN_ROCK:
         ROS_WARN("Oops! You are in Rock!");
         ++cnt_stuck_;
+        is_start_occupied_ = true;
         return true;
       default:
         break;
@@ -567,7 +572,7 @@ protected:
 
     publishDebug();
 
-    goal_updated_ = true;
+    cost_estim_cache_created_ = true;
 
     return true;
   }
@@ -845,7 +850,7 @@ protected:
 
     if (!fast_map_update_)
     {
-      updateGoal(false);
+      createCostEstimCache(false);
       return;
     }
 
@@ -858,7 +863,7 @@ protected:
 
     if (cm_[e] == 100)
     {
-      updateGoal(false);
+      createCostEstimCache(false);
       return;
     }
 
@@ -1009,7 +1014,7 @@ protected:
     prev_map_update_y_min_ = map_info_.height;
     prev_map_update_y_max_ = 0;
 
-    updateGoal();
+    createCostEstimCache();
 
     if (map_update_retained_ && map_update_retained_->header.stamp >= msg->header.stamp)
     {
@@ -1236,7 +1241,7 @@ public:
     has_map_ = false;
     has_goal_ = false;
     has_start_ = false;
-    goal_updated_ = false;
+    cost_estim_cache_created_ = false;
 
     escaping_ = false;
     cnt_stuck_ = 0;
@@ -1327,9 +1332,9 @@ public:
       const ros::Time now = ros::Time::now();
       next_replan_time = now;
 
-      if (has_map_ && !goal_updated_ && has_goal_)
+      if (has_map_ && !cost_estim_cache_created_ && has_goal_)
       {
-        updateGoal();
+        createCostEstimCache();
       }
       bool has_costmap(false);
       if (costmap_watchdog_ > ros::Duration(0))
@@ -1436,36 +1441,44 @@ public:
 
             continue;
           }
-          else if (cnt_stuck_ > 0)
-          {
-            status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
-          }
-          else
+          else if (cost_estim_cache_created_)
           {
             status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
-          }
-          nav_msgs::Path path;
-          path.header = map_header_;
-          path.header.stamp = now;
-          makePlan(start_.pose, goal_.pose, path, true);
-          if (use_path_with_velocity_)
-          {
-            // NaN velocity means that don't care the velocity
-            pub_path_velocity_.publish(
-                trajectory_tracker_msgs::toPathWithVelocity(path, std::numeric_limits<double>::quiet_NaN()));
+            nav_msgs::Path path;
+            path.header = map_header_;
+            path.header.stamp = now;
+            makePlan(start_.pose, goal_.pose, path, true);
+            if (use_path_with_velocity_)
+            {
+              // NaN velocity means that don't care the velocity
+              pub_path_velocity_.publish(
+                  trajectory_tracker_msgs::toPathWithVelocity(path, std::numeric_limits<double>::quiet_NaN()));
+            }
+            else
+            {
+              pub_path_.publish(path);
+            }
+            previous_path = path;
+            if (sw_wait_ > 0.0)
+            {
+              const int sw_index = getSwitchIndex(path);
+              is_path_switchback = (sw_index >= 0);
+              if (is_path_switchback)
+                sw_pos_ = path.poses[sw_index];
+            }
           }
           else
           {
-            pub_path_.publish(path);
-          }
-          previous_path = path;
-
-          if (sw_wait_ > 0.0)
-          {
-            const int sw_index = getSwitchIndex(path);
-            is_path_switchback = (sw_index >= 0);
-            if (is_path_switchback)
-              sw_pos_ = path.poses[sw_index];
+            if (is_start_occupied_)
+            {
+              status_.error = planner_cspace_msgs::PlannerStatus::IN_ROCK;
+            }
+            else
+            {
+              status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
+            }
+            publishEmptyPath();
+            previous_path.poses.clear();
           }
         }
       }
@@ -1528,6 +1541,7 @@ protected:
     if (!cm_.validate(s, range_))
     {
       ROS_ERROR("You are on the edge of the world.");
+      status_.error = planner_cspace_msgs::PlannerStatus::IN_ROCK;
       return false;
     }
 
@@ -1591,7 +1605,7 @@ protected:
         {
           goal_ = goal_raw_;
           escaping_ = false;
-          updateGoal();
+          createCostEstimCache();
           ROS_INFO("Escaped");
           return true;
         }
@@ -1657,7 +1671,7 @@ protected:
           goal_.pose.position.x = x;
           goal_.pose.position.y = y;
 
-          updateGoal();
+          createCostEstimCache();
           return false;
         }
       }

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -551,7 +551,6 @@ protected:
       default:
         break;
     }
-    cnt_stuck_ = 0;
     const auto ts = boost::chrono::high_resolution_clock::now();
     cost_estim_cache_.create(s, e);
     const auto tnow = boost::chrono::high_resolution_clock::now();
@@ -1437,10 +1436,6 @@ public:
 
             continue;
           }
-          else if (cnt_stuck_ > 0)
-          {
-            status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
-          }
           else
           {
             status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
@@ -1529,6 +1524,14 @@ protected:
     if (!cm_.validate(s, range_))
     {
       ROS_ERROR("You are on the edge of the world.");
+      status_.error = planner_cspace_msgs::PlannerStatus::IN_ROCK;
+      return false;
+    }
+
+    if (cm_[e] == 100)
+    {
+      ROS_DEBUG("Planning failed as the goal is occupied.");
+      status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
       return false;
     }
 

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1436,6 +1436,10 @@ public:
 
             continue;
           }
+          else if (cnt_stuck_ > 0)
+          {
+            status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
+          }
           else
           {
             status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
@@ -1524,14 +1528,6 @@ protected:
     if (!cm_.validate(s, range_))
     {
       ROS_ERROR("You are on the edge of the world.");
-      status_.error = planner_cspace_msgs::PlannerStatus::IN_ROCK;
-      return false;
-    }
-
-    if (cm_[e] == 100)
-    {
-      ROS_DEBUG("Planning failed as the goal is occupied.");
-      status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
       return false;
     }
 

--- a/planner_cspace/test/CMakeLists.txt
+++ b/planner_cspace/test/CMakeLists.txt
@@ -79,7 +79,7 @@ add_rostest_gtest(test_navigate
   src/test_navigate.cpp
 )
 target_link_libraries(test_navigate ${catkin_LIBRARIES})
-add_dependencies(test_navigate planner_3d)
+add_dependencies(test_navigate planner_3d patrol)
 
 add_rostest(test/navigation_rostest.test
   ARGS antialias_start:=true

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -87,7 +87,6 @@ protected:
   ros::Publisher pub_map_local_;
   ros::Publisher pub_initial_pose_;
   ros::Publisher pub_patrol_nodes_;
-
   size_t local_map_apply_cnt_;
   std::vector<tf2::Stamped<tf2::Transform>> traj_;
   std::string test_scope_;
@@ -259,13 +258,12 @@ protected:
   {
     ros::spinOnce();
     ASSERT_TRUE(static_cast<bool>(map_));
-    // ASSERT_TRUE(static_cast<bool>(map_local_));
+    ASSERT_TRUE(static_cast<bool>(map_local_));
     pubMapLocal();
     ros::Duration(0.2).sleep();
 
     ros::Rate wait(10);
     ros::Time deadline = ros::Time::now() + ros::Duration(10);
-    bool planning_failed = false;
     while (ros::ok())
     {
       pubMapLocal();
@@ -276,7 +274,6 @@ protected:
 
       if (now > deadline)
       {
-        ROS_ERROR("FAILED");
         dumpRobotTrajectory();
         FAIL()
             << test_scope_ << "/" << name << ": Navigation timeout." << std::endl
@@ -286,7 +283,6 @@ protected:
 
       if (planner_status_->error == expected_error)
       {
-        ROS_ERROR("SUCCEEDED");
         return;
       }
     }

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -582,8 +582,6 @@ TEST_F(Navigate, GoalIsInRockRecovered)
   path.poses[0].pose.position.y = 2.55;
   path.poses[0].pose.orientation.w = 1.0;
   pub_patrol_nodes_.publish(path);
-  tf2::Transform goal;
-  tf2::fromMsg(path.poses.back().pose, goal);
 
   for (int x = 12; x <= 14; ++x)
   {
@@ -620,8 +618,6 @@ TEST_F(Navigate, RobotIsInRockOnRecovered)
   path.poses[0].pose.position.y = 2.55;
   path.poses[0].pose.orientation.w = 1.0;
   pub_patrol_nodes_.publish(path);
-  tf2::Transform goal;
-  tf2::fromMsg(path.poses.back().pose, goal);
 
   for (int x = 23; x <= 26; ++x)
   {


### PR DESCRIPTION
In the current master branch, When `cnt_stuck_` has a positive value, `status.error` becomes `PATH_NOT_FOUND`.  The value of `cnt_stuck_` is incremented when the start or the goal cell is occupied, and it is retained even after the occupied cell is cleared and path planning is succeeded. Therefore, the `status.error` never returns to `GOING_WELL` in such cases. In addition, when the start cell is occupied, `status.error` should become `IN_ROCK`.
This bug is introduced by https://github.com/at-wat/neonavigation/commit/db2532967d0e15f85e7ee8657183abddcb1719ea.

In this PR, `cost_estim_cache_created_` is used to check if the start or goal cell is occupied instead of `cnt_stuck_`.
In addition, `is_start_occupied_` flag is added to distinguish `IN_ROCK` status.
Some inappropriate names of functions and variables are renamed.