### PR TITLE
planner_space: fix segmentation fault on out-of-map

### DIFF
--- a/planner_cspace/src/distance_map.cpp
+++ b/planner_cspace/src/distance_map.cpp
@@ -273,6 +273,12 @@ void DistanceMap::update(
   const Astar::Vec e_rough(e[0], e[1], 0);
   const Astar::Vec s_rough(s[0], s[1], 0);
 
+  if (s_rough.isExceeded(g_.size()) || e_rough.isExceeded(g_.size()))
+  {
+    // Out of the map
+    return;
+  }
+
   if (cost_min != std::numeric_limits<float>::max())
   {
     pq_erase_.emplace(0.0, 0.0, p_cost_min);
@@ -342,12 +348,18 @@ void DistanceMap::update(
 
 void DistanceMap::create(const Astar::Vec& s, const Astar::Vec& e)
 {
+  const Astar::Vec e_rough(e[0], e[1], 0);
+  const Astar::Vec s_rough(s[0], s[1], 0);
+
+  if (s_rough.isExceeded(g_.size()) || e_rough.isExceeded(g_.size()))
+  {
+    // Out of the map
+    return;
+  }
+
   pq_open_.clear();
   pq_erase_.clear();
   g_.clear(std::numeric_limits<float>::max());
-
-  const Astar::Vec e_rough(e[0], e[1], 0);
-  const Astar::Vec s_rough(s[0], s[1], 0);
 
   g_[e_rough] = -p_.euclid_cost[0] * 0.5;  // Decrement to reduce calculation error
   pq_open_.push(Astar::PriorityVec(g_[e_rough], g_[e_rough], e_rough));

--- a/planner_cspace/src/distance_map.cpp
+++ b/planner_cspace/src/distance_map.cpp
@@ -273,11 +273,13 @@ void DistanceMap::update(
   const Astar::Vec e_rough(e[0], e[1], 0);
   const Astar::Vec s_rough(s[0], s[1], 0);
 
+  /*
   if (s_rough.isExceeded(cm_rough_.size()) || e_rough.isExceeded(cm_rough_.size()))
   {
     // Out of the map
     return;
   }
+  */
 
   if (cost_min != std::numeric_limits<float>::max())
   {
@@ -351,11 +353,13 @@ void DistanceMap::create(const Astar::Vec& s, const Astar::Vec& e)
   const Astar::Vec e_rough(e[0], e[1], 0);
   const Astar::Vec s_rough(s[0], s[1], 0);
 
+  /*
   if (s_rough.isExceeded(cm_rough_.size()) || e_rough.isExceeded(cm_rough_.size()))
   {
     // Out of the map
     return;
   }
+  */
 
   pq_open_.clear();
   pq_erase_.clear();

--- a/planner_cspace/src/distance_map.cpp
+++ b/planner_cspace/src/distance_map.cpp
@@ -273,13 +273,11 @@ void DistanceMap::update(
   const Astar::Vec e_rough(e[0], e[1], 0);
   const Astar::Vec s_rough(s[0], s[1], 0);
 
-  /*
   if (s_rough.isExceeded(cm_rough_.size()) || e_rough.isExceeded(cm_rough_.size()))
   {
     // Out of the map
     return;
   }
-  */
 
   if (cost_min != std::numeric_limits<float>::max())
   {
@@ -353,13 +351,11 @@ void DistanceMap::create(const Astar::Vec& s, const Astar::Vec& e)
   const Astar::Vec e_rough(e[0], e[1], 0);
   const Astar::Vec s_rough(s[0], s[1], 0);
 
-  /*
   if (s_rough.isExceeded(cm_rough_.size()) || e_rough.isExceeded(cm_rough_.size()))
   {
     // Out of the map
     return;
   }
-  */
 
   pq_open_.clear();
   pq_erase_.clear();

--- a/planner_cspace/src/distance_map.cpp
+++ b/planner_cspace/src/distance_map.cpp
@@ -273,7 +273,7 @@ void DistanceMap::update(
   const Astar::Vec e_rough(e[0], e[1], 0);
   const Astar::Vec s_rough(s[0], s[1], 0);
 
-  if (s_rough.isExceeded(g_.size()) || e_rough.isExceeded(g_.size()))
+  if (s_rough.isExceeded(cm_rough_.size()) || e_rough.isExceeded(cm_rough_.size()))
   {
     // Out of the map
     return;
@@ -351,7 +351,7 @@ void DistanceMap::create(const Astar::Vec& s, const Astar::Vec& e)
   const Astar::Vec e_rough(e[0], e[1], 0);
   const Astar::Vec s_rough(s[0], s[1], 0);
 
-  if (s_rough.isExceeded(g_.size()) || e_rough.isExceeded(g_.size()))
+  if (s_rough.isExceeded(cm_rough_.size()) || e_rough.isExceeded(cm_rough_.size()))
   {
     // Out of the map
     return;

--- a/planner_cspace/test/src/test_distance_map.cpp
+++ b/planner_cspace/test/src/test_distance_map.cpp
@@ -235,10 +235,10 @@ TEST_F(DistanceMapTest, StartOutOfMap)
 
   const DistanceMap::Rect rect(Vec3(1, 1, 0), Vec3(2, 2, 0));
 
-  dm_.update(Vec3(1000, 1000), e_, rect);
-  dm_.update(Vec3(-1000, 1000), e_, rect);
-  dm_.update(Vec3(-1000, -1000), e_, rect);
-  dm_.update(Vec3(1000, -1000), e_, rect);
+  dm_.update(Astar::Vec(1000, 1000, 0), e_, rect);
+  dm_.update(Astar::Vec(-1000, 1000, 0), e_, rect);
+  dm_.update(Astar::Vec(-1000, -1000, 0), e_, rect);
+  dm_.update(Astar::Vec(1000, -1000, 0), e_, rect);
 }
 
 TEST_F(DistanceMapTest, GoalOutOfMap)
@@ -248,10 +248,10 @@ TEST_F(DistanceMapTest, GoalOutOfMap)
 
   const DistanceMap::Rect rect(Vec3(1, 1, 0), Vec3(2, 2, 0));
 
-  dm_.update(s_, Vec3(1000, 1000), rect);
-  dm_.update(s_, Vec3(-1000, 1000), rect);
-  dm_.update(s_, Vec3(-1000, -1000), rect);
-  dm_.update(s_, Vec3(1000, -1000), rect);
+  dm_.update(s_, Astar::Vec(1000, 1000, 0), rect);
+  dm_.update(s_, Astar::Vec(-1000, 1000, 0), rect);
+  dm_.update(s_, Astar::Vec(-1000, -1000, 0), rect);
+  dm_.update(s_, Astar::Vec(1000, -1000, 0), rect);
 }
 
 TEST_P(DistanceMapTestWithParam, Update)

--- a/planner_cspace/test/src/test_distance_map.cpp
+++ b/planner_cspace/test/src/test_distance_map.cpp
@@ -228,6 +228,32 @@ TEST_F(DistanceMapTest, Create)
   }
 }
 
+TEST_F(DistanceMapTest, StartOutOfMap)
+{
+  setupCostmap();
+  dm_.create(s_, e_);
+
+  const DistanceMap::Rect rect(Vec3(1, 1, 0), Vec3(2, 2, 0));
+
+  dm_.update(Vec3(1000, 1000), e_, rect);
+  dm_.update(Vec3(-1000, 1000), e_, rect);
+  dm_.update(Vec3(-1000, -1000), e_, rect);
+  dm_.update(Vec3(1000, -1000), e_, rect);
+}
+
+TEST_F(DistanceMapTest, GoalOutOfMap)
+{
+  setupCostmap();
+  dm_.create(s_, e_);
+
+  const DistanceMap::Rect rect(Vec3(1, 1, 0), Vec3(2, 2, 0));
+
+  dm_.update(s_, Vec3(1000, 1000), rect);
+  dm_.update(s_, Vec3(-1000, 1000), rect);
+  dm_.update(s_, Vec3(-1000, -1000), rect);
+  dm_.update(s_, Vec3(1000, -1000), rect);
+}
+
 TEST_P(DistanceMapTestWithParam, Update)
 {
   const std::vector<Vec3> obstacles = GetParam();


### PR DESCRIPTION
Test result without the fix:
```
[ RUN      ] DistanceMapTest.StartOutOfMap
[ INFO] [1692768470.380405208]: x:3, y:3 grids around the boundary is ignored on path search
Segmentation fault
-- run_tests.py: verify result "/sq_ws/build/test_results/planner_cspace/gtest-test_distance_map.xml"
Cannot find results, writing failure results to '/sq_ws/build/test_results/planner_cspace/MISSING-gtest-test_distance_map.xml'
```