### PR TITLE
 planner_3d: fix cost calculation bug on in-place turning

### DIFF
--- a/planner_cspace/src/grid_astar_model_3dof.cpp
+++ b/planner_cspace/src/grid_astar_model_3dof.cpp
@@ -155,6 +155,10 @@ float GridAstarModel3D::euclidCostRough(const Vec& v) const
 float GridAstarModel3D::cost(
     const Vec& cur, const Vec& next, const std::vector<VecWithCost>& start, const Vec& goal) const
 {
+  if ((cm_[cur] > 99) || (cm_[next] > 99))
+  {
+    return -1;
+  }
   Vec d_raw = next - cur;
   d_raw.cycle(map_info_.angle);
   const Vec d = d_raw;
@@ -168,11 +172,6 @@ float GridAstarModel3D::cost(
     Vec pos = cur;
     for (int i = 0; i < std::abs(d[2]); i++)
     {
-      pos[2] += dir;
-      if (pos[2] < 0)
-        pos[2] += map_info_.angle;
-      else if (pos[2] >= static_cast<int>(map_info_.angle))
-        pos[2] -= map_info_.angle;
       const auto c = cm_[pos];
       if (c > 99)
         return -1;
@@ -180,6 +179,11 @@ float GridAstarModel3D::cost(
       {
         sum += c;
       }
+      pos[2] += dir;
+      if (pos[2] < 0)
+        pos[2] += map_info_.angle;
+      else if (pos[2] >= static_cast<int>(map_info_.angle))
+        pos[2] -= map_info_.angle;
     }
     const float turn_cost_ratio = cc_.weight_costmap_turn_ / 100.0;
     const float turn_heuristic_cost_ratio =

--- a/planner_cspace/test/src/test_planner_3d_cost.cpp
+++ b/planner_cspace/test/src/test_planner_3d_cost.cpp
@@ -91,6 +91,16 @@ TEST(GridAstarModel3D, Cost)
   EXPECT_LT(c_straight, c_curve);
   EXPECT_LT(c_straight, c_drift);
   EXPECT_LT(c_straight, c_drift_curve);
+
+  // These tests are added to confirm a bug is fixed by https://github.com/at-wat/neonavigation/pull/725
+  const GridAstarModel3D::Vec start2(5, 5, 0);
+  const GridAstarModel3D::Vec occupied(10, 5, 0);
+  const GridAstarModel3D::Vec goal2(10, 5, 3);
+  cm[occupied] = 100;
+  // The cost toward the occupied cell should be negative.
+  EXPECT_LT(model.cost(start2, occupied, {GridAstarModel3D::VecWithCost(start2)}, occupied), 0);
+  // The cost from the occupied cell should be negative.
+  EXPECT_LT(model.cost(occupied, goal2, {GridAstarModel3D::VecWithCost(occupied)}, goal2), 0);
 }
 }  // namespace planner_3d
 }  // namespace planner_cspace

--- a/planner_cspace/test/src/test_planner_3d_cost.cpp
+++ b/planner_cspace/test/src/test_planner_3d_cost.cpp
@@ -95,13 +95,13 @@ TEST(GridAstarModel3D, Cost)
 
   // These tests are added to confirm that some bugs are fixed by https://github.com/at-wat/neonavigation/pull/725
   const GridAstarModel3D::Vec start2(5, 5, 0);
-  const GridAstarModel3D::Vec occupied(10, 5, 0);
+  const GridAstarModel3D::Vec occupied_waypoint(10, 5, 0);
   const GridAstarModel3D::Vec goal2(10, 5, 3);
-  cm[occupied] = 100;
+  cm[occupied_waypoint] = 100;
   // The cost toward the occupied cell should be negative.
-  EXPECT_LT(model.cost(start2, occupied, {GridAstarModel3D::VecWithCost(start2)}, occupied), 0);
+  EXPECT_LT(model.cost(start2, occupied_waypoint, {GridAstarModel3D::VecWithCost(start2)}, occupied_waypoint), 0);
   // The cost from the occupied cell should be negative.
-  EXPECT_LT(model.cost(occupied, goal2, {GridAstarModel3D::VecWithCost(occupied)}, goal2), 0);
+  EXPECT_LT(model.cost(occupied_waypoint, goal2, {GridAstarModel3D::VecWithCost(occupied_waypoint)}, goal2), 0);
 
   const GridAstarModel3D::Vec start3(10, 20, 0);
   cm[start3] = 99;
@@ -110,7 +110,7 @@ TEST(GridAstarModel3D, Cost)
   // The cost between start3 and waypoint3 is larger than the cost between waypoint3 and goal3 because start3
   // has a penalty.
   EXPECT_GT(model.cost(start3, waypoint3, {GridAstarModel3D::VecWithCost(start3)}, waypoint3),
-            model.cost(waypoint3, waypoint3, {GridAstarModel3D::VecWithCost(goal3)}, goal3));
+            model.cost(waypoint3, goal3, {GridAstarModel3D::VecWithCost(waypoint3)}, goal3));
 }
 }  // namespace planner_3d
 }  // namespace planner_cspace

--- a/planner_cspace/test/src/test_planner_3d_cost.cpp
+++ b/planner_cspace/test/src/test_planner_3d_cost.cpp
@@ -66,6 +66,7 @@ TEST(GridAstarModel3D, Cost)
   cc.max_vel_ = 1.0;
   cc.max_ang_vel_ = 1.0;
   cc.angle_resolution_aspect_ = 1.0;
+  cc.turn_penalty_cost_threshold_ = 0;
 
   GridAstarModel3D model(
       map_info,
@@ -92,7 +93,7 @@ TEST(GridAstarModel3D, Cost)
   EXPECT_LT(c_straight, c_drift);
   EXPECT_LT(c_straight, c_drift_curve);
 
-  // These tests are added to confirm a bug is fixed by https://github.com/at-wat/neonavigation/pull/725
+  // These tests are added to confirm that some bugs are fixed by https://github.com/at-wat/neonavigation/pull/725
   const GridAstarModel3D::Vec start2(5, 5, 0);
   const GridAstarModel3D::Vec occupied(10, 5, 0);
   const GridAstarModel3D::Vec goal2(10, 5, 3);
@@ -101,6 +102,15 @@ TEST(GridAstarModel3D, Cost)
   EXPECT_LT(model.cost(start2, occupied, {GridAstarModel3D::VecWithCost(start2)}, occupied), 0);
   // The cost from the occupied cell should be negative.
   EXPECT_LT(model.cost(occupied, goal2, {GridAstarModel3D::VecWithCost(occupied)}, goal2), 0);
+
+  const GridAstarModel3D::Vec start3(10, 20, 0);
+  cm[start3] = 99;
+  const GridAstarModel3D::Vec waypoint3(10, 20, 3);
+  const GridAstarModel3D::Vec goal3(10, 20, 6);
+  // The cost between start3 and waypoint3 is larger than the cost between waypoint3 and goal3 because start3
+  // has a penalty.
+  EXPECT_GT(model.cost(start3, waypoint3, {GridAstarModel3D::VecWithCost(start3)}, waypoint3),
+            model.cost(waypoint3, waypoint3, {GridAstarModel3D::VecWithCost(goal3)}, goal3));
 }
 }  // namespace planner_3d
 }  // namespace planner_cspace


### PR DESCRIPTION
This PR fixes a bug in `GridAstarModel3D::cost()`.

When the movement between `cur` and `next` is an in-place turning, `cm_[cur]` is not evaluated. I think it is a simple mistake.
In contrast, when the movement between `cur` and `next` is not an in-place turning, `MotionCache` is used to interpolate the movement of the robot. Because `MotionCache::Page::getMotion()` does not return the last pose (I guess this is needed to avoid double counting of costs), the `cm_[next]` is not evaluated. Therefore, when only the `cm_[next]` is 100 and the costs of other poses are not 100, `GridAstarModel3D::cost()` returns a positive value mistakenly.

Because of these bugs, the planner_3d could create a path in which the robot collides with an obstacle in the following situation.
Assume that the cost of the grid (10, 5, 0) is 100, and the costs of other grids are not 100. For example, the path (5, 5, 0) -> (10, 5, 0) -> (10, 5, 3) can be generated. 
The interpolated poses between (5, 5, 0) to (10, 5, 0) generated by `MotionCache` do not include (10, 5, 0) as it is the last pose, so the cost of the grid (10, 5, 0) is not evaluated. 
The interpolated poses between (10, 5, 0) to (10, 5, 3) do not include the first pose (10, 5, 0) because of the bug in the cost calculation of in-place turning motion.
As a result, the cost of (10, 5, 0) is never evaluated and planner_3d can generate an untraversable path.