### PR TITLE
costmap_3d: avoid unnecessary grid expansions

### DIFF
--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/base.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/base.h
@@ -321,14 +321,12 @@ public:
         map_->data[i + yaw * xy_size] = -1;
       }
     }
-    const auto m1 = ros::WallTime::now();
     updateCSpace(
         base_map,
         UpdatedRegion(
             0, 0, 0,
             map_->info.width, map_->info.height, map_->info.angle,
             map_->header.stamp));
-    ROS_WARN("INITAL updateCSpace: %f", (ros::WallTime::now() - m1).toSec());
     for (size_t yaw = 0; yaw < map_->info.angle; yaw++)
     {
       for (unsigned int i = 0; i < xy_size; i++)
@@ -414,9 +412,7 @@ protected:
     {
       if (map_->header.frame_id == map_updated_->header.frame_id)
       {
-        const auto m1 = ros::WallTime::now();
         updateCSpace(map_updated_, region_);
-        ROS_WARN("Update: %f", (ros::WallTime::now() - m1).toSec());
       }
       else
       {

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/base.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/base.h
@@ -321,12 +321,14 @@ public:
         map_->data[i + yaw * xy_size] = -1;
       }
     }
+    const auto m1 = ros::WallTime::now();
     updateCSpace(
         base_map,
         UpdatedRegion(
             0, 0, 0,
             map_->info.width, map_->info.height, map_->info.angle,
             map_->header.stamp));
+    ROS_WARN("INITAL updateCSpace: %f", (ros::WallTime::now() - m1).toSec());
     for (size_t yaw = 0; yaw < map_->info.angle; yaw++)
     {
       for (unsigned int i = 0; i < xy_size; i++)
@@ -412,7 +414,9 @@ protected:
     {
       if (map_->header.frame_id == map_updated_->header.frame_id)
       {
+        const auto m1 = ros::WallTime::now();
         updateCSpace(map_updated_, region_);
+        ROS_WARN("Update: %f", (ros::WallTime::now() - m1).toSec());
       }
       else
       {

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/footprint.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/footprint.h
@@ -70,8 +70,6 @@ protected:
     int x_min, x_max, y_min, y_max;
   };
   std::vector<Rect> template_ranges_;
-  Rect default_range_;
-
   int range_max_;
   std::vector<bool> unknown_buf_;
 
@@ -195,11 +193,11 @@ public:
         cs_template_.e(0, 0, yaw) = 100;
     }
 
-    default_range_ = {-range_max_, range_max_, -range_max_, range_max_};
+    const Rect default_range = {-range_max_, range_max_, -range_max_, range_max_};
     template_ranges_.resize(16);
     for (size_t i = 0; i < template_ranges_.size(); i++)
     {
-      template_ranges_[i] = default_range_;
+      template_ranges_[i] = default_range;
       if (i & 1)
       {
         template_ranges_[i].x_min = 0;
@@ -299,7 +297,7 @@ protected:
 
   const Rect& getDefaultRange(const nav_msgs::OccupancyGrid::ConstPtr&, const int) const
   {
-    return default_range_;
+    return template_ranges_[0];
   }
   const Rect& getMaskedRange(const nav_msgs::OccupancyGrid::ConstPtr& msg, const int pos) const
   {

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/footprint.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/footprint.h
@@ -194,13 +194,12 @@ public:
       if (footprint_radius_ == 0)
         cs_template_.e(0, 0, yaw) = 100;
     }
+
+    default_range_ = {-range_max_, range_max_, -range_max_, range_max_};
     template_ranges_.resize(16);
     for (size_t i = 0; i < template_ranges_.size(); i++)
     {
-      template_ranges_[i].x_min = -range_max_;
-      template_ranges_[i].x_max = range_max_;
-      template_ranges_[i].y_min = -range_max_;
-      template_ranges_[i].y_max = range_max_;
+      template_ranges_[i] = default_range_;
       if (i & 1)
       {
         template_ranges_[i].x_min = 0;
@@ -218,7 +217,6 @@ public:
         template_ranges_[i].y_max = 0;
       }
     }
-    default_range_ = {-range_max_, range_max_, -range_max_, range_max_};
   }
 
 protected:
@@ -308,19 +306,19 @@ protected:
     const int gx = pos % msg->info.width;
     const int gy = pos / msg->info.width;
     uint8_t mask = 0;
-    if (gx == 0 || (msg->data[pos - 1] == 100))
+    if (gx == 0 || (msg->data[pos - 1] >= msg->data[pos]))
     {
       mask += 1;
     }
-    if (gx == static_cast<int>(msg->info.width) - 1 || (msg->data[pos + 1] == 100))
+    if (gx == static_cast<int>(msg->info.width) - 1 || (msg->data[pos + 1] >= msg->data[pos]))
     {
       mask += 2;
     }
-    if (gy == 0 || (msg->data[pos - msg->info.width] == 100))
+    if (gy == 0 || (msg->data[pos - msg->info.width] >= msg->data[pos]))
     {
       mask += 4;
     }
-    if (gy == static_cast<int>(msg->info.height) - 1 || (msg->data[pos + msg->info.width] == 100))
+    if (gy == static_cast<int>(msg->info.height) - 1 || (msg->data[pos + msg->info.width] >= msg->data[pos]))
     {
       mask += 8;
     }

--- a/costmap_cspace/include/costmap_cspace/costmap_3d_layer/footprint.h
+++ b/costmap_cspace/include/costmap_cspace/costmap_3d_layer/footprint.h
@@ -287,9 +287,9 @@ protected:
       result.y_max =
           (gy == static_cast<int>(msg->info.height) - 1 || (*(ptr + msg->info.width) >= *ptr)) ? 0 : range_max_;
     };
-    const auto range_getter = (msg->info.resolution == map->info.linear_resolution) ?
-                                  getMaskedRange :
-                                  std::function<void(const int, Rect&)>([](const int, Rect&) {});
+    const auto getRange = (msg->info.resolution == map->info.linear_resolution) ?
+                              getMaskedRange :
+                              std::function<void(const int, Rect&)>([](const int, Rect&) {});
 
     const int ox =
         std::lround((msg->info.origin.position.x - map->info.origin.position.x) / map->info.linear_resolution);
@@ -333,7 +333,7 @@ protected:
           m = 0;
         continue;
       }
-      range_getter(i, range);
+      getRange(i, range);
       const int map_x_min = std::max(gx + range.x_min, 0);
       const int map_x_max = std::min(gx + range.x_max, static_cast<int>(map->info.width) - 1);
       const int map_y_min = std::max(gy + range.y_min, 0);


### PR DESCRIPTION
![Screenshot from 2023-10-31 18-11-30](https://github.com/at-wat/neonavigation/assets/8833040/3f38b843-7fb2-42ca-a6c1-ce4d3931fd59)

Assume that there are 3 consecutive occupied grid cells on an `OccupancyGrid`, and `costmap_3d` expands these cells.
The black cells in the diagram above are the occupied cells, and the yellow, green, and red cells are expanded cells. 
The nearest occupied cell from the yellow cells is the left one, the nearest occupied cell from the green cells is the center one, and the nearest occupied cell from the red cell is the right one. Therefore, the expansion process for the left cell should be performed on the yellow cells, the process for the center cell on the green cells, and the process for the right cell on the red cells respectively.
By this PR, the expansion ranges are limited when adjacent cells have the same or larger costs than the expanding cell. Since occupied cells on the occupancy grid map are rarely isolated, this algorithm can speed up the expansion process. Note that this algorithm is effective only when the costmap and the `OccupancyGrid` have the same resolution.

The calculation time of `Costmap3dLayerFootprint::updateCSpace()` on my laptop (Map size: 4.5K x 2.4K x 16, the number of occupied cells: 188K) 
Master branch: 5.118 seconds
This PR: 0.335 seconds