### PR TITLE
planner_3d: add an option to trigger planning by costmap updates

### DIFF
--- a/planner_cspace/cfg/Planner3D.cfg
+++ b/planner_cspace/cfg/Planner3D.cfg
@@ -48,5 +48,6 @@ gen.add("fast_map_update", bool_t, 0, "", False)
 gen.add("max_retry_num", int_t, 0, "", -1, -1, 100)
 gen.add("keep_a_part_of_previous_path", bool_t, 0, "If true, a part of the previous path is preserved to avoid radical path changes.", False)
 gen.add("dist_stop_to_previous_path", double_t, 0, "Valid only when keep_a_part_of_previous_path is true. This should be the same as dist_stop parameter of trajectory_tracker.", 0.1, 0.0, 1.0)
+gen.add("trigger_plan_by_costmap_update", bool_t, 0, "", False)
 
 exit(gen.generate(PACKAGE, "planner_cspace", "Planner3D"))

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -744,7 +744,6 @@ protected:
       map_update_retained_ = msg;
       return;
     }
-    map_update_retained_ = nullptr;
 
     last_costmap_ = now;
 
@@ -824,6 +823,7 @@ protected:
         }
       }
     }
+    map_update_retained_ = nullptr;
     const auto ts_cm_init_end = boost::chrono::high_resolution_clock::now();
     const float ts_cm_init_dur = boost::chrono::duration<float>(ts_cm_init_end - ts_cm_init_start).count();
     ROS_DEBUG("Costmaps updated (%.4f)", ts_cm_init_dur);

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -723,7 +723,7 @@ protected:
     previous_path_ = path;
   }
 
-  void applyCostmapUpdate(const costmap_cspace_msgs::CSpace3DUpdate::ConstPtr msg)
+  void applyCostmapUpdate(const costmap_cspace_msgs::CSpace3DUpdate::ConstPtr& msg)
   {
     const auto ts_cm_init_start = boost::chrono::high_resolution_clock::now();
     const ros::Time now = ros::Time::now();
@@ -914,7 +914,7 @@ protected:
     no_map_update_timer_ =
         nh_.createTimer(costmap_watchdog_, &Planner3dNode::cbNoMapUpdateTimer, this, true);
   }
-  void cbMapUpdate(const costmap_cspace_msgs::CSpace3DUpdate::ConstPtr msg)
+  void cbMapUpdate(const costmap_cspace_msgs::CSpace3DUpdate::ConstPtr& msg)
   {
     if (!has_map_)
       return;
@@ -923,11 +923,6 @@ protected:
     {
       no_map_update_timer_.stop();
       updateStart();
-      if (jump_.detectJump())
-      {
-        bbf_costmap_.clear();
-        // Robot pose jumped.
-      }
       applyCostmapUpdate(msg);
       planPath(last_costmap_);
       if (costmap_watchdog_ > ros::Duration(0))
@@ -1648,6 +1643,10 @@ public:
     {
       if (trigger_plan_by_costmap_update_)
       {
+        if (jump_.detectJump())
+        {
+          bbf_costmap_.clear();
+        }
         ros::spinOnce();
         r.sleep();
       }

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1467,7 +1467,6 @@ public:
 
   void planPath(const ros::Time& now)
   {
-    ROS_INFO("replan called");
     if (has_map_ && !cost_estim_cache_created_ && has_goal_)
     {
       createCostEstimCache();
@@ -1504,7 +1503,6 @@ public:
 
     if (has_map_ && has_goal_ && has_start_ && has_costmap)
     {
-      ROS_INFO("Generating path");
       if (act_->isActive())
       {
         move_base_msgs::MoveBaseFeedback feedback;
@@ -1565,7 +1563,6 @@ public:
           has_goal_ = false;
 
           publishEmptyPath();
-          // next_replan_time += ros::Duration(1.0 / freq_);
           ROS_ERROR("Exceeded max_retry_num:%d", max_retry_num_);
 
           if (act_->isActive())
@@ -1616,7 +1613,6 @@ public:
     }
     else if (!has_goal_)
     {
-      ROS_INFO("No goal");
       if (!retain_last_error_status_)
         status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
       publishEmptyPath();

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1397,6 +1397,7 @@ public:
     }
     start_pose_predictor_.setConfig(start_pose_predictor_config);
     trigger_plan_by_costmap_update_ = config.trigger_plan_by_costmap_update;
+    no_map_update_timer_.stop();
   }
 
   GridAstarModel3D::Vec pathPose2Grid(const geometry_msgs::PoseStamped& pose) const

--- a/planner_cspace/test/src/test_dynamic_parameter_change.cpp
+++ b/planner_cspace/test/src/test_dynamic_parameter_change.cpp
@@ -193,7 +193,7 @@ protected:
     pub_map_overlay_.publish(map_overlay_);
   }
 
-  double getAveragePathInterval(const ros::Duration costmap_publishing_interval)
+  double getAveragePathInterval(const ros::Duration& costmap_publishing_interval)
   {
     publishMapAndRobot(2.55, 0.45, M_PI);
     ros::Duration(0.3).sleep();


### PR DESCRIPTION
When `trigger_plan_by_costmap_update` option is true, `planner_3d` makes a new path soon after CSpace3DUpdate message is subscribed. 
With this option,  the updates of the costmap are reflected in path planning quickly.