### PR TITLE
planner_cspace: reconstuct GridAstarModel3D only when necessary

### DIFF
--- a/planner_cspace/include/planner_cspace/planner_3d/grid_astar_model.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/grid_astar_model.h
@@ -90,7 +90,7 @@ protected:
   const BlockMemGridmapBase<char, 3, 2>& cm_;
   const BlockMemGridmapBase<char, 3, 2>& cm_hyst_;
   const BlockMemGridmapBase<char, 3, 2>& cm_rough_;
-  const CostCoeff& cc_;
+  CostCoeff cc_;
   int range_;
   RotationCache rot_cache_;
   MotionCache motion_cache_;
@@ -112,6 +112,9 @@ public:
       const int range,
       const float path_interpolation_resolution = 0.5,
       const float grid_enumeration_resolution = 0.1);
+  void updateCostParameters(
+      const Vecf& euclid_cost_coef,
+      const CostCoeff& cc);
   void enableHysteresis(const bool enable);
   void createEuclidCostCache();
   float euclidCost(const Vec& v) const;

--- a/planner_cspace/include/planner_cspace/planner_3d/grid_astar_model.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/grid_astar_model.h
@@ -114,7 +114,9 @@ public:
       const float grid_enumeration_resolution = 0.1);
   void updateCostParameters(
       const Vecf& euclid_cost_coef,
-      const CostCoeff& cc);
+      const CostCoeff& cc,
+      const int local_range);
+
   void enableHysteresis(const bool enable);
   void createEuclidCostCache();
   float euclidCost(const Vec& v) const;

--- a/planner_cspace/src/grid_astar_model_3dof.cpp
+++ b/planner_cspace/src/grid_astar_model_3dof.cpp
@@ -103,9 +103,7 @@ GridAstarModel3D::GridAstarModel3D(
       min_boundary_;
   ROS_INFO("x:%d, y:%d grids around the boundary is ignored on path search", min_boundary_[0], min_boundary_[1]);
 
-  createEuclidCostCache();
-
-  motion_primitives_ = MotionPrimitiveBuilder::build(map_info_, cc_, range_);
+  updateCostParameters(euclid_cost_coef_, cc_, local_range_);
   search_list_rough_.clear();
   Vec d;
   for (d[0] = -range_; d[0] <= range_; d[0]++)
@@ -122,10 +120,12 @@ GridAstarModel3D::GridAstarModel3D(
 
 void GridAstarModel3D::updateCostParameters(
     const Vecf& euclid_cost_coef,
-    const CostCoeff& cc)
+    const CostCoeff& cc,
+    const int local_range)
 {
   euclid_cost_coef_ = euclid_cost_coef;
   cc_ = cc;
+  local_range_ = local_range;
   createEuclidCostCache();
   motion_primitives_ = MotionPrimitiveBuilder::build(map_info_, cc_, range_);
 }

--- a/planner_cspace/src/grid_astar_model_3dof.cpp
+++ b/planner_cspace/src/grid_astar_model_3dof.cpp
@@ -120,6 +120,16 @@ GridAstarModel3D::GridAstarModel3D(
   }
 }
 
+void GridAstarModel3D::updateCostParameters(
+    const Vecf& euclid_cost_coef,
+    const CostCoeff& cc)
+{
+  euclid_cost_coef_ = euclid_cost_coef;
+  cc_ = cc;
+  createEuclidCostCache();
+  motion_primitives_ = MotionPrimitiveBuilder::build(map_info_, cc_, range_);
+}
+
 void GridAstarModel3D::enableHysteresis(const bool enable)
 {
   hysteresis_ = enable;

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -964,7 +964,7 @@ protected:
         map_info_.angular_resolution != msg->info.angular_resolution)
     {
       map_info_ = msg->info;
-      resetGridAstarModel();
+      resetGridAstarModel(true);
       ROS_DEBUG("Search model updated");
     }
     else
@@ -1291,8 +1291,10 @@ public:
     parameter_server_.setCallback(boost::bind(&Planner3dNode::cbParameter, this, _1, _2));
   }
 
-  void resetGridAstarModel()
+  void resetGridAstarModel(const bool force_reset)
   {
+    const int previous_range = range_;
+    const int previous_local_range = local_range_;
     range_ = static_cast<int>(search_range_ / map_info_.linear_resolution);
     hist_ignore_range_ = std::lround(hist_ignore_range_f_ / map_info_.linear_resolution);
     hist_ignore_range_max_ = std::lround(hist_ignore_range_max_f_ / map_info_.linear_resolution);
@@ -1305,13 +1307,21 @@ public:
     goal_tolerance_ang_ = std::lround(goal_tolerance_ang_f_ / map_info_.angular_resolution);
     cc_.angle_resolution_aspect_ = 2.0 / tanf(map_info_.angular_resolution);
 
-    model_.reset(
-        new GridAstarModel3D(
-            map_info_,
-            ec_,
-            local_range_,
-            cost_estim_cache_.gridmap(), cm_, cm_hyst_, cm_rough_,
-            cc_, range_, path_interpolation_resolution_, grid_enumeration_resolution_));
+    const bool reset_required = force_reset || (previous_range != range_) || (previous_local_range != local_range_);
+    if (reset_required)
+    {
+      model_.reset(
+          new GridAstarModel3D(
+              map_info_,
+              ec_,
+              local_range_,
+              cost_estim_cache_.gridmap(), cm_, cm_hyst_, cm_rough_,
+              cc_, range_, path_interpolation_resolution_, grid_enumeration_resolution_));
+    }
+    else
+    {
+      model_->updateCostParameters(ec_, cc_);
+    }
   }
 
   void cbParameter(const Planner3DConfig& config, const uint32_t /* level */)
@@ -1371,7 +1381,7 @@ public:
 
     if (map_info_.linear_resolution != 0.0 && map_info_.angular_resolution != 0.0)
     {
-      resetGridAstarModel();
+      resetGridAstarModel(false);
       const Astar::Vec size2d(static_cast<int>(map_info_.width), static_cast<int>(map_info_.height), 1);
       const DistanceMap::Params dmp =
           {

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1294,7 +1294,6 @@ public:
   void resetGridAstarModel(const bool force_reset)
   {
     const int previous_range = range_;
-    const int previous_local_range = local_range_;
     range_ = static_cast<int>(search_range_ / map_info_.linear_resolution);
     hist_ignore_range_ = std::lround(hist_ignore_range_f_ / map_info_.linear_resolution);
     hist_ignore_range_max_ = std::lround(hist_ignore_range_max_f_ / map_info_.linear_resolution);
@@ -1307,7 +1306,7 @@ public:
     goal_tolerance_ang_ = std::lround(goal_tolerance_ang_f_ / map_info_.angular_resolution);
     cc_.angle_resolution_aspect_ = 2.0 / tanf(map_info_.angular_resolution);
 
-    const bool reset_required = force_reset || (previous_range != range_) || (previous_local_range != local_range_);
+    const bool reset_required = force_reset || (previous_range != range_);
     if (reset_required)
     {
       model_.reset(
@@ -1320,7 +1319,7 @@ public:
     }
     else
     {
-      model_->updateCostParameters(ec_, cc_);
+      model_->updateCostParameters(ec_, cc_, local_range_);
     }
   }
 


### PR DESCRIPTION
When the parameters of planner_3D are changed using dynamic_reconfigure, the instance of GridAstarModel3D is always reconstructed. This makes the dynamic_reconfigure response time slow when the map is large.
This PR modifies the resetGridAstarModel() function to reconstruct the instance of GridAstarModel3D only when the map is changed or the `range_` parameter, which relates to the primal member variables in GridAstarModel3D, is updated.