### PR TITLE
trajectory_tracker: fix the method for projecting paths onto 2D

### DIFF
--- a/trajectory_tracker/test/include/trajectory_tracker_test.h
+++ b/trajectory_tracker/test/include/trajectory_tracker_test.h
@@ -106,8 +106,6 @@ private:
     if (cmd_vel_time_ == ros::Time(0))
       cmd_vel_time_ = now;
     const float dt = std::min((now - cmd_vel_time_).toSec(), 0.1);
-
-    const double yaw_diff = msg->angular.z * dt;
     const tf2::Transform pose_diff(tf2::Quaternion(tf2::Vector3(0, 0, 1), msg->angular.z * dt),
                                    tf2::Vector3(msg->linear.x * dt, 0, 0));
     pose_ *= pose_diff;

--- a/trajectory_tracker/test/src/test_trajectory_tracker.cpp
+++ b/trajectory_tracker/test/src/test_trajectory_tracker.cpp
@@ -33,6 +33,8 @@
 
 #include <trajectory_tracker_test.h>
 
+#include <angles/angles.h>
+
 TEST_F(TrajectoryTrackerTest, StraightStop)
 {
   initState(Eigen::Vector2d(0, 0), 0);
@@ -51,8 +53,8 @@ TEST_F(TrajectoryTrackerTest, StraightStop)
     {
       FAIL()
           << "Timeout" << std::endl
-          << "Pos " << pos_ << std::endl
-          << "Yaw " << yaw_ << std::endl
+          << "Pos " << getPos() << std::endl
+          << "Yaw " << getYaw() << std::endl
           << "Status " << std::endl
           << status_ << std::endl;
     }
@@ -73,11 +75,11 @@ TEST_F(TrajectoryTrackerTest, StraightStop)
     }
 
     // Check multiple times to assert overshoot.
-    ASSERT_NEAR(yaw_, 0.0, error_ang_)
+    ASSERT_NEAR(getYaw(), 0.0, error_ang_)
         << "[overshoot after goal (" << j << ")] ";
-    ASSERT_NEAR(pos_[0], 0.5, error_lin_)
+    ASSERT_NEAR(getPos()[0], 0.5, error_lin_)
         << "[overshoot after goal (" << j << ")] ";
-    ASSERT_NEAR(pos_[1], 0.0, error_lin_)
+    ASSERT_NEAR(getPos()[1], 0.0, error_lin_)
         << "[overshoot after goal (" << j << ")] ";
   }
   ASSERT_EQ(last_path_header_.stamp, status_->path_header.stamp);
@@ -112,8 +114,8 @@ TEST_F(TrajectoryTrackerTest, StraightStopOvershoot)
       {
         FAIL()
             << "Timeout" << std::endl
-            << "Pos " << pos_ << std::endl
-            << "Yaw " << yaw_ << std::endl
+            << "Pos " << getPos() << std::endl
+            << "Yaw " << getYaw() << std::endl
             << "Status " << std::endl
             << status_ << std::endl
             << info_message;
@@ -135,13 +137,13 @@ TEST_F(TrajectoryTrackerTest, StraightStopOvershoot)
       }
 
       // Check multiple times to assert overshoot.
-      ASSERT_NEAR(yaw_, 0.0, error_ang_)
+      ASSERT_NEAR(getYaw(), 0.0, error_ang_)
           << "[overshoot after goal (" << j << ")] "
           << info_message;
-      EXPECT_NEAR(pos_[0], 0.5, error_lin_)
+      EXPECT_NEAR(getPos()[0], 0.5, error_lin_)
           << "[overshoot after goal (" << j << ")] "
           << info_message;
-      ASSERT_NEAR(pos_[1], 0.0, error_lin_)
+      ASSERT_NEAR(getPos()[1], 0.0, error_lin_)
           << "[overshoot after goal (" << j << ")] "
           << info_message;
     }
@@ -173,8 +175,8 @@ TEST_F(TrajectoryTrackerTest, StraightStopConvergence)
       {
         FAIL()
             << "Timeout" << std::endl
-            << "Pos " << pos_ << std::endl
-            << "Yaw " << yaw_ << std::endl
+            << "Pos " << getPos() << std::endl
+            << "Yaw " << getYaw() << std::endl
             << "Status " << std::endl
             << status_ << std::endl
             << info_message;
@@ -196,13 +198,13 @@ TEST_F(TrajectoryTrackerTest, StraightStopConvergence)
       }
 
       // Check multiple times to assert overshoot.
-      EXPECT_NEAR(yaw_, 0.0, error_ang_)
+      EXPECT_NEAR(getYaw(), 0.0, error_ang_)
           << "[overshoot after goal (" << j << ")] "
           << info_message;
-      EXPECT_NEAR(pos_[0], path_length, error_lin_)
+      EXPECT_NEAR(getPos()[0], path_length, error_lin_)
           << "[overshoot after goal (" << j << ")] "
           << info_message;
-      EXPECT_NEAR(pos_[1], 0.0, error_lin_)
+      EXPECT_NEAR(getPos()[1], 0.0, error_lin_)
           << "[overshoot after goal (" << j << ")] "
           << info_message;
     }
@@ -230,8 +232,8 @@ TEST_F(TrajectoryTrackerTest, StraightVelocityChange)
     {
       FAIL()
           << "Timeout" << std::endl
-          << "Pos " << pos_ << std::endl
-          << "Yaw " << yaw_ << std::endl
+          << "Pos " << getPos() << std::endl
+          << "Yaw " << getYaw() << std::endl
           << "Status " << std::endl
           << status_ << std::endl;
     }
@@ -240,11 +242,11 @@ TEST_F(TrajectoryTrackerTest, StraightVelocityChange)
     rate.sleep();
     ros::spinOnce();
 
-    if (0.3 < pos_[0] && pos_[0] < 0.35)
+    if (0.3 < getPos()[0] && getPos()[0] < 0.35)
     {
       ASSERT_NEAR(cmd_vel_->linear.x, 0.3, error_lin_);
     }
-    else if (0.95 < pos_[0] && pos_[0] < 1.0)
+    else if (0.95 < getPos()[0] && getPos()[0] < 1.0)
     {
       ASSERT_NEAR(cmd_vel_->linear.x, 0.5, error_lin_);
     }
@@ -262,11 +264,11 @@ TEST_F(TrajectoryTrackerTest, StraightVelocityChange)
     }
 
     // Check multiple times to assert overshoot.
-    ASSERT_NEAR(yaw_, 0.0, error_ang_)
+    ASSERT_NEAR(getYaw(), 0.0, error_ang_)
         << "[overshoot after goal (" << j << ")] ";
-    ASSERT_NEAR(pos_[0], 1.5, error_lin_)
+    ASSERT_NEAR(getPos()[0], 1.5, error_lin_)
         << "[overshoot after goal (" << j << ")] ";
-    ASSERT_NEAR(pos_[1], 0.0, error_lin_)
+    ASSERT_NEAR(getPos()[1], 0.0, error_lin_)
         << "[overshoot after goal (" << j << ")] ";
   }
   ASSERT_EQ(last_path_header_.stamp, status_->path_header.stamp);
@@ -298,8 +300,8 @@ TEST_F(TrajectoryTrackerTest, CurveFollow)
     {
       FAIL()
           << "Timeout" << std::endl
-          << "Pos " << pos_ << std::endl
-          << "Yaw " << yaw_ << std::endl
+          << "Pos " << getPos() << std::endl
+          << "Yaw " << getYaw() << std::endl
           << "Status " << std::endl
           << status_ << std::endl;
     }
@@ -320,11 +322,11 @@ TEST_F(TrajectoryTrackerTest, CurveFollow)
     }
 
     // Check multiple times to assert overshoot.
-    ASSERT_NEAR(yaw_, p[2], error_ang_)
+    ASSERT_NEAR(getYaw(), p[2], error_ang_)
         << "[overshoot after goal (" << j << ")] ";
-    ASSERT_NEAR(pos_[0], p[0], error_large_lin_)
+    ASSERT_NEAR(getPos()[0], p[0], error_large_lin_)
         << "[overshoot after goal (" << j << ")] ";
-    ASSERT_NEAR(pos_[1], p[1], error_large_lin_)
+    ASSERT_NEAR(getPos()[1], p[1], error_large_lin_)
         << "[overshoot after goal (" << j << ")] ";
   }
   ASSERT_EQ(last_path_header_.stamp, status_->path_header.stamp);
@@ -374,8 +376,8 @@ TEST_F(TrajectoryTrackerTest, InPlaceTurn)
             FAIL()
                 << condition_name.str()
                 << "Timeout" << std::endl
-                << "Pos " << pos_ << std::endl
-                << "Yaw " << yaw_ << std::endl
+                << "Pos " << getPos() << std::endl
+                << "Yaw " << getYaw() << std::endl
                 << "Status " << std::endl
                 << status_ << std::endl;
           }
@@ -411,7 +413,8 @@ TEST_F(TrajectoryTrackerTest, InPlaceTurn)
           }
 
           // Check multiple times to assert overshoot.
-          ASSERT_NEAR(yaw_, init_yaw + angles.back(), error_ang_)
+          const double angle_diff = std::abs(angles::shortest_angular_distance(getYaw(), init_yaw + angles.back()));
+          ASSERT_LT(angle_diff, error_ang_)
               << "[overshoot after goal (" << j << ")] "
               << condition_name.str();
         }
@@ -447,8 +450,8 @@ TEST_F(TrajectoryTrackerTest, SwitchBack)
     {
       FAIL()
           << "Timeout" << std::endl
-          << "Pos " << pos_ << std::endl
-          << "Yaw " << yaw_ << std::endl
+          << "Pos " << getPos() << std::endl
+          << "Yaw " << getYaw() << std::endl
           << "Status " << std::endl
           << status_ << std::endl;
     }
@@ -469,11 +472,11 @@ TEST_F(TrajectoryTrackerTest, SwitchBack)
     }
 
     // Check multiple times to assert overshoot.
-    ASSERT_NEAR(yaw_, p[2], error_ang_)
+    ASSERT_NEAR(getYaw(), p[2], error_ang_)
         << "[overshoot after goal (" << j << ")] ";
-    ASSERT_NEAR(pos_[0], p[0], error_large_lin_)
+    ASSERT_NEAR(getPos()[0], p[0], error_large_lin_)
         << "[overshoot after goal (" << j << ")] ";
-    ASSERT_NEAR(pos_[1], p[1], error_large_lin_)
+    ASSERT_NEAR(getPos()[1], p[1], error_large_lin_)
         << "[overshoot after goal (" << j << ")] ";
   }
   ASSERT_EQ(last_path_header_.stamp, status_->path_header.stamp);
@@ -509,8 +512,8 @@ TEST_F(TrajectoryTrackerTest, SwitchBackWithPathUpdate)
     {
       FAIL()
           << "Timeout" << std::endl
-          << "Pos " << pos_ << std::endl
-          << "Yaw " << yaw_ << std::endl
+          << "Pos " << getPos() << std::endl
+          << "Yaw " << getYaw() << std::endl
           << "Status " << std::endl
           << status_ << std::endl;
     }
@@ -521,7 +524,7 @@ TEST_F(TrajectoryTrackerTest, SwitchBackWithPathUpdate)
     if (status_->status == trajectory_tracker_msgs::TrajectoryTrackerStatus::GOAL)
       break;
 
-    if ((pos_local_goal - pos_).norm() < 0.1)
+    if ((pos_local_goal - getPos()).norm() < 0.1)
       cnt_arrive_local_goal++;
 
     if (i % 5)
@@ -549,11 +552,62 @@ TEST_F(TrajectoryTrackerTest, SwitchBackWithPathUpdate)
     }
 
     // Check multiple times to assert overshoot.
-    ASSERT_NEAR(yaw_, p[2], error_ang_)
+    ASSERT_NEAR(getYaw(), p[2], error_ang_)
         << "[overshoot after goal (" << j << ")] ";
-    ASSERT_NEAR(pos_[0], p[0], error_large_lin_)
+    ASSERT_NEAR(getPos()[0], p[0], error_large_lin_)
         << "[overshoot after goal (" << j << ")] ";
-    ASSERT_NEAR(pos_[1], p[1], error_large_lin_)
+    ASSERT_NEAR(getPos()[1], p[1], error_large_lin_)
+        << "[overshoot after goal (" << j << ")] ";
+  }
+  ASSERT_EQ(last_path_header_.stamp, status_->path_header.stamp);
+}
+
+TEST_F(TrajectoryTrackerTest, FarAray)
+{
+  const double y_pos = 500.0;
+
+  initState(tf2::Transform(tf2::Quaternion(tf2::Vector3(1.0, 0.0, 0.0), 0.1), tf2::Vector3(0.0, y_pos, 0.0)));
+  std::vector<Eigen::Vector3d> poses;
+  for (double x = 0.0; x < 0.5; x += 0.01)
+    poses.push_back(Eigen::Vector3d(x, y_pos, 0.0));
+  poses.push_back(Eigen::Vector3d(0.5, y_pos, 0.0));
+  waitUntilStart(std::bind(&TrajectoryTrackerTest::publishPath, this, poses));
+
+  ros::Rate rate(50);
+  const ros::Time start = ros::Time::now();
+  while (ros::ok())
+  {
+    if (ros::Time::now() > start + ros::Duration(10.0))
+    {
+      FAIL()
+          << "Timeout" << std::endl
+          << "Pos " << getPos() << std::endl
+          << "Yaw " << getYaw() << std::endl
+          << "Status " << std::endl
+          << status_ << std::endl;
+    }
+
+    publishTransform();
+    rate.sleep();
+    ros::spinOnce();
+    if (status_->status == trajectory_tracker_msgs::TrajectoryTrackerStatus::GOAL)
+      break;
+  }
+  for (int j = 0; j < 5; ++j)
+  {
+    for (int i = 0; i < 5; ++i)
+    {
+      publishTransform();
+      rate.sleep();
+      ros::spinOnce();
+    }
+
+    // Check multiple times to assert overshoot.
+    ASSERT_NEAR(getYaw(), 0.0, error_ang_)
+        << "[overshoot after goal (" << j << ")] ";
+    ASSERT_NEAR(getPos()[0], 0.5, error_lin_)
+        << "[overshoot after goal (" << j << ")] ";
+    ASSERT_NEAR(getPos()[1], y_pos, error_lin_)
         << "[overshoot after goal (" << j << ")] ";
   }
   ASSERT_EQ(last_path_header_.stamp, status_->path_header.stamp);

--- a/trajectory_tracker/test/src/test_trajectory_tracker.cpp
+++ b/trajectory_tracker/test/src/test_trajectory_tracker.cpp
@@ -33,8 +33,6 @@
 
 #include <trajectory_tracker_test.h>
 
-#include <angles/angles.h>
-
 TEST_F(TrajectoryTrackerTest, StraightStop)
 {
   initState(Eigen::Vector2d(0, 0), 0);
@@ -413,7 +411,8 @@ TEST_F(TrajectoryTrackerTest, InPlaceTurn)
           }
 
           // Check multiple times to assert overshoot.
-          const double angle_diff = std::abs(angles::shortest_angular_distance(getYaw(), init_yaw + angles.back()));
+          const double angle_diff = pose_.getRotation().angleShortestPath(
+              tf2::Quaternion(tf2::Vector3(0, 0, 1), init_yaw + angles.back()));
           ASSERT_LT(angle_diff, error_ang_)
               << "[overshoot after goal (" << j << ")] "
               << condition_name.str();

--- a/trajectory_tracker/test/src/test_trajectory_tracker_with_odom.cpp
+++ b/trajectory_tracker/test/src/test_trajectory_tracker_with_odom.cpp
@@ -60,9 +60,9 @@ TEST_F(TrajectoryTrackerTest, FrameRate)
     rate.sleep();
     ros::spinOnce();
   }
-  ASSERT_NEAR(yaw_, 0.0, 1e-2);
-  ASSERT_NEAR(pos_[0], 0.5, 1e-2);
-  ASSERT_NEAR(pos_[1], 0.0, 1e-2);
+  ASSERT_NEAR(getYaw(), 0.0, 1e-2);
+  ASSERT_NEAR(getPos()[0], 0.5, 1e-2);
+  ASSERT_NEAR(getPos()[1], 0.0, 1e-2);
   ASSERT_EQ(last_path_header_.stamp, status_->path_header.stamp);
   // Parameter "hz" is set to 30.0, but the actual frame rate is around 50.0 as it is syncronized with the odometry.
   ASSERT_NEAR(50.0, frame_rate, 10.0);
@@ -91,8 +91,8 @@ TEST_F(TrajectoryTrackerTest, Timeout)
 
   ASSERT_FLOAT_EQ(cmd_vel_->linear.x, 0.0);
   ASSERT_FLOAT_EQ(cmd_vel_->angular.z, 0.0);
-  ASSERT_GT(pos_[0], 0.0);
-  ASSERT_LT(pos_[0], 2.0);
+  ASSERT_GT(getPos()[0], 0.0);
+  ASSERT_LT(getPos()[0], 2.0);
   ASSERT_EQ(status_->status, trajectory_tracker_msgs::TrajectoryTrackerStatus::NO_PATH);
 
   while (ros::ok())
@@ -109,9 +109,9 @@ TEST_F(TrajectoryTrackerTest, Timeout)
     rate.sleep();
     ros::spinOnce();
   }
-  ASSERT_NEAR(yaw_, 0.0, 1e-2);
-  ASSERT_NEAR(pos_[0], 2.0, 1e-2);
-  ASSERT_NEAR(pos_[1], 0.0, 1e-2);
+  ASSERT_NEAR(getYaw(), 0.0, 1e-2);
+  ASSERT_NEAR(getPos()[0], 2.0, 1e-2);
+  ASSERT_NEAR(getPos()[1], 0.0, 1e-2);
   ASSERT_EQ(last_path_header_.stamp, status_->path_header.stamp);
 }
 


### PR DESCRIPTION
The current method can cause large errors when the robot's coordinates are far from the origin and the ground is not flat. This PR fixes this problem and adds a corresponding test.