### PR TITLE
planner_cspace: fix error status during crowd escape

### DIFF
--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1628,6 +1628,7 @@ public:
       }
       else
       {
+        bool tried_escape = escaping_;
         bool skip_path_planning = false;
         if (escaping_)
         {
@@ -1684,6 +1685,13 @@ public:
             is_path_switchback_ = (sw_index >= 0);
             if (is_path_switchback_)
               sw_pos_ = path.poses[sw_index];
+          }
+          if ((escaping_ || tried_escape) && enable_crowd_mode_ &&
+              status_.error == planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND)
+          {
+            // Ignore PATH_NOT_FOUND during temporary escape with crowd mode as the robot continue moving forward.
+            // TODO(at-wat): Add temporary_escape status field to planner_cspace_msgs::PlannerStatus
+            status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
           }
         }
       }

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -752,6 +752,8 @@ TEST_F(Navigate, RobotIsInCrowd)
       continue;
     }
 
+    EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::GOING_WELL);
+
     const auto goal_rel = trans.inverse() * goal;
     if (goal_rel.getOrigin().length() < 0.2 &&
         std::abs(tf2::getYaw(goal_rel.getRotation())) < 0.2 &&
@@ -840,6 +842,8 @@ TEST_F(Navigate, ForceTemporaryEscape)
       std::cerr << test_scope_ << e.what() << std::endl;
       continue;
     }
+
+    EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::GOING_WELL);
 
     const auto goal_rel = trans.inverse() * goal;
     if (goal_rel.getOrigin().length() < 0.2 &&

--- a/planner_cspace/test/test/navigation_rostest.test
+++ b/planner_cspace/test/test/navigation_rostest.test
@@ -4,7 +4,7 @@
   <arg name="fast_map_update" default="false" />
   <arg name="with_tolerance" default="false" />
   <arg name="enable_crowd_mode" default="false" />
-  <env name="GCOV_PREFIX" value="/tmp/gcov/planner_cspace_navigation_$(arg antialias_start)_$(arg fast_map_update)_$(arg with_tolerance)" />
+  <env name="GCOV_PREFIX" value="/tmp/gcov/planner_cspace_navigation_$(arg antialias_start)_$(arg fast_map_update)_$(arg with_tolerance)_$(arg enable_crowd_mode)" />
   <param name="neonavigation_compatible" value="1" />
 
   <test test-name="test_navigate_$(arg antialias_start)_$(arg fast_map_update)_$(arg with_tolerance)_$(arg enable_crowd_mode)" pkg="planner_cspace" type="test_navigate" time-limit="260.0">


### PR DESCRIPTION
Don't output planner error status while temporary escaping with crowd escape mode.