### PR TITLE
planner_cspace: fix crowd escape to use original goal if reachable

### DIFF
--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -2202,11 +2202,6 @@ protected:
           {
             continue;
           }
-          const auto cost = cost_estim_cache_static_[te];
-          if (cost >= cost_min)
-          {
-            continue;
-          }
 
           // Check arrivability
           if (arrivable_map_[te - local_origin] == std::numeric_limits<float>::max())
@@ -2222,6 +2217,12 @@ protected:
             escaping_ = false;
             createCostEstimCache();
             return;
+          }
+
+          const auto cost = cost_estim_cache_static_[te];
+          if (cost >= cost_min)
+          {
+            continue;
           }
 
           // Calculate distance map gradient

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -2198,7 +2198,7 @@ protected:
           {
             continue;
           }
-          if (!cm_rough_.validate(te, range_) || cm_rough_[te] >= relocation_acceptable_cost_)
+          if (!cm_rough_.validate(te, range_))
           {
             continue;
           }
@@ -2217,6 +2217,11 @@ protected:
             escaping_ = false;
             createCostEstimCache();
             return;
+          }
+
+          if (cm_rough_[te] >= relocation_acceptable_cost_)
+          {
+            continue;
           }
 
           const auto cost = cost_estim_cache_static_[te];


### PR DESCRIPTION
If the original goal cell cost is higher than the temporary goal select threshold, the goal wasn't rollback to the original goal even if it's reachable.
Fix goal rollback condition evaluation order.