### PR TITLE
planner_cspace: output corresponding error status during temporary escape

### DIFF
--- a/planner_cspace/include/planner_cspace/planner_3d/temporary_escape.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/temporary_escape.h
@@ -36,22 +36,21 @@ namespace planner_cspace
 {
 namespace planner_3d
 {
-enum class TemporaryEscapeReason
+enum class TemporaryEscapeStatus
 {
-  FORCED,
-  UNREACHABLE,
-  GOAL_IS_IN_ROCK,
+  NOT_ESCAPING,
+  ESCAPING_WITH_IMPROVEMENT,
+  ESCAPING_WITHOUT_IMPROVEMENT,
 };
 
-uint8_t temporaryEscapeReason2PlannerErrorStatus(const TemporaryEscapeReason r)
+uint8_t temporaryEscapeStatus2PlannerErrorStatus(const TemporaryEscapeStatus r)
 {
   switch (r)
   {
-    case TemporaryEscapeReason::FORCED:
+    case TemporaryEscapeStatus::NOT_ESCAPING:
+    case TemporaryEscapeStatus::ESCAPING_WITH_IMPROVEMENT:
       return planner_cspace_msgs::PlannerStatus::GOING_WELL;
-    case TemporaryEscapeReason::UNREACHABLE:
-      return planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
-    case TemporaryEscapeReason::GOAL_IS_IN_ROCK:
+    case TemporaryEscapeStatus::ESCAPING_WITHOUT_IMPROVEMENT:
       return planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
     default:
       return planner_cspace_msgs::PlannerStatus::INTERNAL_ERROR;

--- a/planner_cspace/include/planner_cspace/planner_3d/temporary_escape.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/temporary_escape.h
@@ -61,6 +61,12 @@ uint8_t temporaryEscapeStatus2PlannerErrorStatus(const TemporaryEscapeStatus r)
       return planner_cspace_msgs::PlannerStatus::INTERNAL_ERROR;
   }
 }
+
+TemporaryEscapeStatus operator|(const TemporaryEscapeStatus& a, const TemporaryEscapeStatus& b)
+{
+  // Return worst one
+  return a > b ? a : b;
+}
 }  // namespace planner_3d
 }  // namespace planner_cspace
 

--- a/planner_cspace/include/planner_cspace/planner_3d/temporary_escape.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/temporary_escape.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, the neonavigation authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLANNER_CSPACE_PLANNER_3D_TEMPORARY_ESCAPE_H
+#define PLANNER_CSPACE_PLANNER_3D_TEMPORARY_ESCAPE_H
+
+namespace planner_cspace
+{
+namespace planner_3d
+{
+enum class TemporaryEscapeReason
+{
+  FORCED,
+  UNREACHABLE,
+  GOAL_IS_IN_ROCK,
+};
+}  // namespace planner_3d
+}  // namespace planner_cspace
+
+#endif  // PLANNER_CSPACE_PLANNER_3D_TEMPORARY_ESCAPE_H
+

--- a/planner_cspace/include/planner_cspace/planner_3d/temporary_escape.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/temporary_escape.h
@@ -43,6 +43,11 @@ enum class TemporaryEscapeStatus
   ESCAPING_WITHOUT_IMPROVEMENT,
 };
 
+bool isEscaping(const TemporaryEscapeStatus r)
+{
+  return r != TemporaryEscapeStatus::NOT_ESCAPING;
+}
+
 uint8_t temporaryEscapeStatus2PlannerErrorStatus(const TemporaryEscapeStatus r)
 {
   switch (r)

--- a/planner_cspace/include/planner_cspace/planner_3d/temporary_escape.h
+++ b/planner_cspace/include/planner_cspace/planner_3d/temporary_escape.h
@@ -30,6 +30,8 @@
 #ifndef PLANNER_CSPACE_PLANNER_3D_TEMPORARY_ESCAPE_H
 #define PLANNER_CSPACE_PLANNER_3D_TEMPORARY_ESCAPE_H
 
+#include <planner_cspace_msgs/PlannerStatus.h>
+
 namespace planner_cspace
 {
 namespace planner_3d
@@ -40,6 +42,21 @@ enum class TemporaryEscapeReason
   UNREACHABLE,
   GOAL_IS_IN_ROCK,
 };
+
+uint8_t temporaryEscapeReason2PlannerErrorStatus(const TemporaryEscapeReason r)
+{
+  switch (r)
+  {
+    case TemporaryEscapeReason::FORCED:
+      return planner_cspace_msgs::PlannerStatus::GOING_WELL;
+    case TemporaryEscapeReason::UNREACHABLE:
+      return planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
+    case TemporaryEscapeReason::GOAL_IS_IN_ROCK:
+      return planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
+    default:
+      return planner_cspace_msgs::PlannerStatus::INTERNAL_ERROR;
+  }
+}
 }  // namespace planner_3d
 }  // namespace planner_cspace
 

--- a/planner_cspace/src/patrol.cpp
+++ b/planner_cspace/src/patrol.cpp
@@ -60,7 +60,7 @@ protected:
 
   void cbPath(const nav_msgs::Path::ConstPtr& msg)
   {
-    if (path_.poses.size() > 0)
+    if (msg->poses.size() > 0)
     {
       if (with_tolerance_)
       {

--- a/planner_cspace/src/patrol.cpp
+++ b/planner_cspace/src/patrol.cpp
@@ -62,6 +62,7 @@ protected:
   {
     if (path_.poses.size() > 0)
     {
+      // Cancel previous patrol if stored
       if (with_tolerance_)
       {
         act_cli_tolerant_->cancelAllGoals();

--- a/planner_cspace/src/patrol.cpp
+++ b/planner_cspace/src/patrol.cpp
@@ -60,6 +60,17 @@ protected:
 
   void cbPath(const nav_msgs::Path::ConstPtr& msg)
   {
+    if (path_.poses.size() > 0)
+    {
+      if (with_tolerance_)
+      {
+        act_cli_tolerant_->cancelAllGoals();
+      }
+      else
+      {
+        act_cli_->cancelAllGoals();
+      }
+    }
     path_ = *msg;
     pos_ = 0;
   }

--- a/planner_cspace/src/patrol.cpp
+++ b/planner_cspace/src/patrol.cpp
@@ -60,7 +60,7 @@ protected:
 
   void cbPath(const nav_msgs::Path::ConstPtr& msg)
   {
-    if (msg->poses.size() > 0)
+    if (path_.poses.size() > 0)
     {
       if (with_tolerance_)
       {

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1626,11 +1626,7 @@ public:
       {
         bool tried_escape = escaping_;
         bool skip_path_planning = false;
-        if (escaping_)
-        {
-          status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
-        }
-        else if (max_retry_num_ != -1 && cnt_stuck_ > max_retry_num_)
+        if (max_retry_num_ != -1 && cnt_stuck_ > max_retry_num_)
         {
           status_.error = planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND;
           status_.status = planner_cspace_msgs::PlannerStatus::DONE;
@@ -1682,12 +1678,11 @@ public:
             if (is_path_switchback_)
               sw_pos_ = path.poses[sw_index];
           }
-          if ((escaping_ || tried_escape) && enable_crowd_mode_ &&
-              status_.error == planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND)
+          if (escaping_ || tried_escape)
           {
-            // Ignore PATH_NOT_FOUND during temporary escape with crowd mode as the robot continue moving forward.
+            // Planner status is obtained by escape_reason_ during temporary escape.
             // TODO(at-wat): Add temporary_escape status field to planner_cspace_msgs::PlannerStatus
-            status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
+            status_.error = temporaryEscapeReason2PlannerErrorStatus(escape_reason_);
           }
         }
       }

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -1680,10 +1680,9 @@ public:
           }
           if (isEscaping(escape_status_) || isEscaping(previous_escape_status))
           {
-            // Planner status is obtained by escape_status_ during temporary escape.
+            // Planner error status is obtained by escape_status_ during temporary escape.
             // TODO(at-wat): Add temporary_escape status field to planner_cspace_msgs::PlannerStatus
-            status_.error = temporaryEscapeStatus2PlannerErrorStatus(
-                escape_status_ | previous_escape_status);
+            status_.error = temporaryEscapeStatus2PlannerErrorStatus(escape_status_ | previous_escape_status);
           }
         }
       }
@@ -1691,9 +1690,7 @@ public:
     else if (!has_goal_)
     {
       if (!retain_last_error_status_)
-      {
         status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
-      }
       publishEmptyPath();
     }
     publishCurrentGoal();
@@ -2272,8 +2269,7 @@ protected:
               TemporaryEscapeStatus::ESCAPING_WITHOUT_IMPROVEMENT;
       if (isPathFinishing(start_grid, te_out))
       {
-        // This temporary goal is too close and
-        // it will be immediately goes escaped state
+        // This temporary goal is too close and it will be immediately goes escaped state
         escape_status_ = TemporaryEscapeStatus::ESCAPING_WITHOUT_IMPROVEMENT;
       }
 

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -449,7 +449,6 @@ protected:
     has_goal_ = false;
     escape_status_ = TemporaryEscapeStatus::NOT_ESCAPING;
     status_.status = planner_cspace_msgs::PlannerStatus::DONE;
-    status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
   }
 
   bool setGoal(const geometry_msgs::PoseStamped& msg)
@@ -479,7 +478,6 @@ protected:
         return false;
       }
       status_.status = planner_cspace_msgs::PlannerStatus::DOING;
-      status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
       status_.header.stamp = ros::Time::now();
       pub_status_.publish(status_);
       diag_updater_.update();
@@ -1693,7 +1691,9 @@ public:
     else if (!has_goal_)
     {
       if (!retain_last_error_status_)
+      {
         status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
+      }
       publishEmptyPath();
     }
     publishCurrentGoal();

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -447,7 +447,9 @@ protected:
       act_tolerant_->setPreempted(planner_cspace_msgs::MoveWithToleranceResult(), "Preempted.");
 
     has_goal_ = false;
+    escape_status_ = TemporaryEscapeStatus::NOT_ESCAPING;
     status_.status = planner_cspace_msgs::PlannerStatus::DONE;
+    status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
   }
 
   bool setGoal(const geometry_msgs::PoseStamped& msg)
@@ -477,6 +479,7 @@ protected:
         return false;
       }
       status_.status = planner_cspace_msgs::PlannerStatus::DOING;
+      status_.error = planner_cspace_msgs::PlannerStatus::GOING_WELL;
       status_.header.stamp = ros::Time::now();
       pub_status_.publish(status_);
       diag_updater_.update();

--- a/planner_cspace/src/planner_3d.cpp
+++ b/planner_cspace/src/planner_3d.cpp
@@ -2267,7 +2267,7 @@ protected:
 
       escaping_ = true;
       escape_status_ =
-          cost_min < cost_estim_cache_static_[start_grid] ?
+          cost_min < cost_estim_cache_static_[s] ?
               TemporaryEscapeStatus::ESCAPING_WITH_IMPROVEMENT :
               TemporaryEscapeStatus::ESCAPING_WITHOUT_IMPROVEMENT;
 

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -191,6 +191,7 @@ protected:
     // Clear goal
     nav_msgs::Path path;
     pub_patrol_nodes_.publish(path);
+    ros::Duration(2.0).sleep();
   }
   void cbCostmap(const costmap_cspace_msgs::CSpace3D::ConstPtr& msg)
   {
@@ -398,7 +399,6 @@ TEST_F(Navigate, Navigate)
         std::abs(tf2::getYaw(goal_rel.getRotation())) < 0.2)
     {
       std::cerr << test_scope_ << "Navigation success." << std::endl;
-      ros::Duration(2.0).sleep();
       return;
     }
 
@@ -479,7 +479,6 @@ TEST_F(Navigate, NavigateWithLocalMap)
         std::abs(tf2::getYaw(goal_rel.getRotation())) < 0.2)
     {
       std::cerr << test_scope_ << "Navagation success." << std::endl;
-      ros::Duration(2.0).sleep();
       return;
     }
 
@@ -767,7 +766,6 @@ TEST_F(Navigate, RobotIsInCrowd)
         planner_status_->status == planner_cspace_msgs::PlannerStatus::DONE)
     {
       std::cerr << test_scope_ << "Navigation success." << std::endl;
-      ros::Duration(2.0).sleep();
       return;
     }
 
@@ -998,7 +996,6 @@ TEST_F(Navigate, ForceTemporaryEscape)
         planner_status_->status == planner_cspace_msgs::PlannerStatus::DONE)
     {
       std::cerr << test_scope_ << "Navigation success." << std::endl;
-      ros::Duration(2.0).sleep();
       return;
     }
   }

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -949,7 +949,7 @@ TEST_F(Navigate, CrowdEscapeButNoValidTemporaryGoal)
 
   ros::Rate wait(10);
   bool unreachable = false;
-  const ros::Time check_until = ros::Time::now() + ros::Duration(3);
+  const ros::Time check_until = ros::Time::now() + ros::Duration(2);
   while (ros::ok())
   {
     const size_t gx = path.poses[0].pose.position.x / map_->info.resolution;
@@ -970,11 +970,15 @@ TEST_F(Navigate, CrowdEscapeButNoValidTemporaryGoal)
 
     const ros::Time now = ros::Time::now();
 
-    // Temporary goal is selected on a cell with cost<50 by default.
-    // No temporary goal should be selected on this map.
-    EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND);
+    if (planner_status_->status == planner_cspace_msgs::PlannerStatus::DOING)
+    {
+      // Temporary goal is selected from cells with cost<50 by default.
+      // No temporary goal should be selected on this map.
+      EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND);
+    }
     if (now > check_until)
     {
+      EXPECT_EQ(planner_status_->status, planner_cspace_msgs::PlannerStatus::DOING);
       return;
     }
   }

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -842,7 +842,7 @@ TEST_F(Navigate, RobotIsInCrowdAndStuck)
     if (planner_status_->error == planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND && !unreachable)
     {
       unreachable = true;
-      check_until = now + ros::Duration(3);  // Check another 3 seconds that state is not changed
+      check_until = now + ros::Duration(2);  // Check another 2 seconds that state is not changed
     }
     if (unreachable)
     {
@@ -914,7 +914,7 @@ TEST_F(Navigate, RobotIsInCrowdAndGoalIsInRock)
     if (planner_status_->error == planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND && !unreachable)
     {
       unreachable = true;
-      check_until = now + ros::Duration(3);  // Check another 3 seconds that state is not changed
+      check_until = now + ros::Duration(2);  // Check another 2 seconds that state is not changed
     }
     if (unreachable)
     {

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -102,7 +102,7 @@ protected:
     pub_patrol_nodes_ = nh_.advertise<nav_msgs::Path>("patrol_nodes", 1, true);
   }
 
-  virtual void SetUp()
+  void SetUp() override
   {
     test_scope_ =
         "[" + std::to_string(getpid()) + "/" +
@@ -185,6 +185,12 @@ protected:
     srv_forget_.call(req, res);
 
     ros::Duration(1.0).sleep();
+  }
+  void TearDown() override
+  {
+    // Clear goal
+    nav_msgs::Path path;
+    pub_patrol_nodes_.publish(path);
   }
   void cbCostmap(const costmap_cspace_msgs::CSpace3D::ConstPtr& msg)
   {

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -781,6 +781,146 @@ TEST_F(Navigate, RobotIsInCrowd)
   }
 }
 
+TEST_F(Navigate, RobotIsInCrowdAndStuck)
+{
+  if (!pnh_.param("enable_crowd_mode", false))
+  {
+    GTEST_SKIP() << "enable_crowd_mode is not set";
+  }
+
+  ros::spinOnce();
+  ASSERT_TRUE(static_cast<bool>(map_));
+  ASSERT_TRUE(static_cast<bool>(map_local_));
+
+  nav_msgs::Path path;
+  path.poses.resize(1);
+  path.header.frame_id = "map";
+  path.poses[0].header.frame_id = path.header.frame_id;
+  path.poses[0].pose.position.x = 1.6;
+  path.poses[0].pose.position.y = 2.2;
+  path.poses[0].pose.orientation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0.0, 0.0, 1.0), 1.57));
+  pub_patrol_nodes_.publish(path);
+
+  tf2::Transform goal;
+  tf2::fromMsg(path.poses.back().pose, goal);
+
+  ros::Rate wait(10);
+  bool unreachable = false;
+  const ros::Time deadline = ros::Time::now() + ros::Duration(60);
+  ros::Time check_until = deadline;
+  while (ros::ok())
+  {
+    const size_t data_size = map_local_->data.size();
+    for (int x = 0; x < map_local_->info.width; ++x)
+    {
+      const size_t y = 1.1 / map_->info.resolution;
+      map_local_->data[x + y * map_local_->info.width] = 100;
+    }
+    pubMapLocal();
+
+    ros::spinOnce();
+    wait.sleep();
+
+    const ros::Time now = ros::Time::now();
+
+    if (now > deadline)
+    {
+      dumpRobotTrajectory();
+      FAIL()
+          << test_scope_ << "Navigation timeout." << std::endl
+          << "now: " << now << std::endl
+          << "status: " << planner_status_;
+      break;
+    }
+
+    if (planner_status_->error == planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND && !unreachable)
+    {
+      unreachable = true;
+      check_until = now + ros::Duration(3);  // Check another 3 seconds that state is not changed
+    }
+    if (unreachable)
+    {
+      EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND);
+    }
+    if (now > check_until)
+    {
+      return;
+    }
+  }
+}
+
+TEST_F(Navigate, RobotIsInCrowdAndGoalIsInRock)
+{
+  if (!pnh_.param("enable_crowd_mode", false))
+  {
+    GTEST_SKIP() << "enable_crowd_mode is not set";
+  }
+
+  ros::spinOnce();
+  ASSERT_TRUE(static_cast<bool>(map_));
+  ASSERT_TRUE(static_cast<bool>(map_local_));
+
+  nav_msgs::Path path;
+  path.poses.resize(1);
+  path.header.frame_id = "map";
+  path.poses[0].header.frame_id = path.header.frame_id;
+  path.poses[0].pose.position.x = 1.5;
+  path.poses[0].pose.position.y = 0.45;
+  path.poses[0].pose.orientation.z = 1.0;
+  pub_patrol_nodes_.publish(path);
+
+  tf2::Transform goal;
+  tf2::fromMsg(path.poses.back().pose, goal);
+
+  ros::Rate wait(10);
+  bool unreachable = false;
+  const ros::Time deadline = ros::Time::now() + ros::Duration(60);
+  ros::Time check_until = deadline;
+  while (ros::ok())
+  {
+    const size_t data_size = map_local_->data.size();
+    const size_t gx = path.poses[0].pose.position.x / map_->info.resolution;
+    const size_t gy = path.poses[0].pose.position.y / map_->info.resolution;
+    for (int x = gx - 2; x <= gx + 2; ++x)
+    {
+      for (int y = gy - 2; y <= gy + 2; ++y)
+      {
+        map_local_->data[x + y * map_local_->info.width] = 100;
+      }
+    }
+    pubMapLocal();
+
+    ros::spinOnce();
+    wait.sleep();
+
+    const ros::Time now = ros::Time::now();
+
+    if (now > deadline)
+    {
+      dumpRobotTrajectory();
+      FAIL()
+          << test_scope_ << "Navigation timeout." << std::endl
+          << "now: " << now << std::endl
+          << "status: " << planner_status_;
+      break;
+    }
+
+    if (planner_status_->error == planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND && !unreachable)
+    {
+      unreachable = true;
+      check_until = now + ros::Duration(3);  // Check another 3 seconds that state is not changed
+    }
+    if (unreachable)
+    {
+      EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND);
+    }
+    if (now > check_until)
+    {
+      return;
+    }
+  }
+}
+
 TEST_F(Navigate, ForceTemporaryEscape)
 {
   if (!pnh_.param("enable_crowd_mode", false))

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -950,6 +950,7 @@ TEST_F(Navigate, CrowdEscapeButNoValidTemporaryGoal)
   ros::Rate wait(10);
   bool unreachable = false;
   const ros::Time check_until = ros::Time::now() + ros::Duration(2);
+  int cnt_planning = 0;
   while (ros::ok())
   {
     const size_t gx = path.poses[0].pose.position.x / map_->info.resolution;
@@ -972,13 +973,17 @@ TEST_F(Navigate, CrowdEscapeButNoValidTemporaryGoal)
 
     if (planner_status_->status == planner_cspace_msgs::PlannerStatus::DOING)
     {
-      // Temporary goal is selected from cells with cost<50 by default.
-      // No temporary goal should be selected on this map.
-      EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND);
+      if (cnt_planning > 1)
+      {
+        // Temporary goal is selected from cells with cost<50 by default.
+        // No temporary goal should be selected on this map.
+        EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND);
+      }
+      cnt_planning++;
     }
     if (now > check_until)
     {
-      EXPECT_EQ(planner_status_->status, planner_cspace_msgs::PlannerStatus::DOING);
+      EXPECT_GT(cnt_planning, 2);
       return;
     }
   }

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -754,15 +754,7 @@ TEST_F(Navigate, RobotIsInCrowd)
 
     const auto goal_rel = trans.inverse() * goal;
 
-    if (planner_status_->status == planner_cspace_msgs::PlannerStatus::DOING &&
-        goal_rel.getOrigin().length() > 0.8)
-    {
-      EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND);
-    }
-    else if (goal_rel.getOrigin().length() < 0.5)
-    {
-      EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::GOING_WELL);
-    }
+    EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::GOING_WELL);
 
     if (goal_rel.getOrigin().length() < 0.2 &&
         std::abs(tf2::getYaw(goal_rel.getRotation())) < 0.2 &&

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -757,10 +757,9 @@ TEST_F(Navigate, RobotIsInCrowd)
       continue;
     }
 
-    const auto goal_rel = trans.inverse() * goal;
-
     EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::GOING_WELL);
 
+    const auto goal_rel = trans.inverse() * goal;
     if (goal_rel.getOrigin().length() < 0.2 &&
         std::abs(tf2::getYaw(goal_rel.getRotation())) < 0.2 &&
         planner_status_->status == planner_cspace_msgs::PlannerStatus::DONE)

--- a/planner_cspace/test/src/test_navigate.cpp
+++ b/planner_cspace/test/src/test_navigate.cpp
@@ -752,9 +752,18 @@ TEST_F(Navigate, RobotIsInCrowd)
       continue;
     }
 
-    EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::GOING_WELL);
-
     const auto goal_rel = trans.inverse() * goal;
+
+    if (planner_status_->status == planner_cspace_msgs::PlannerStatus::DOING &&
+        goal_rel.getOrigin().length() > 0.8)
+    {
+      EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::PATH_NOT_FOUND);
+    }
+    else if (goal_rel.getOrigin().length() < 0.5)
+    {
+      EXPECT_EQ(planner_status_->error, planner_cspace_msgs::PlannerStatus::GOING_WELL);
+    }
+
     if (goal_rel.getOrigin().length() < 0.2 &&
         std::abs(tf2::getYaw(goal_rel.getRotation())) < 0.2 &&
         planner_status_->status == planner_cspace_msgs::PlannerStatus::DONE)

--- a/planner_cspace/test/test/navigation_rostest.test
+++ b/planner_cspace/test/test/navigation_rostest.test
@@ -36,6 +36,7 @@
     <param name="fast_map_update" value="$(arg fast_map_update)" />
     <param name="enable_crowd_mode" value="$(arg enable_crowd_mode)" />
     <param name="temporary_escape" value="$(arg enable_crowd_mode)" />
+    <param name="retain_last_error_status" value="false" />
   </node>
   <node pkg="trajectory_tracker" type="trajectory_tracker" name="spur">
     <param name="max_vel" value="0.1" />


### PR DESCRIPTION
Output error status if temporary escape doesn't help.

`Dtg`: distance between the temporary goal and the final goal
`Drg`: distance between the robot and the final goal

- temporary escaping and `Dtg` < `Drg`: `GOING_WELL` (not stuck)
- temporary escaping and `Dtg` >= `Drg`: `PATH_NOT_FOUND` (stuck)