### PR TITLE
Update required cmake version

### DIFF
--- a/costmap_cspace/CMakeLists.txt
+++ b/costmap_cspace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(costmap_cspace)
 
 set(CATKIN_DEPENDS

--- a/costmap_cspace/CMakeLists.txt
+++ b/costmap_cspace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(costmap_cspace)
 
 set(CATKIN_DEPENDS

--- a/joystick_interrupt/CMakeLists.txt
+++ b/joystick_interrupt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(joystick_interrupt)
 
 set(CATKIN_DEPENDS

--- a/joystick_interrupt/CMakeLists.txt
+++ b/joystick_interrupt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(joystick_interrupt)
 
 set(CATKIN_DEPENDS

--- a/map_organizer/CMakeLists.txt
+++ b/map_organizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(map_organizer)
 
 set(CATKIN_DEPENDS

--- a/map_organizer/CMakeLists.txt
+++ b/map_organizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(map_organizer)
 
 set(CATKIN_DEPENDS

--- a/neonavigation/CMakeLists.txt
+++ b/neonavigation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(neonavigation)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/neonavigation/CMakeLists.txt
+++ b/neonavigation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(neonavigation)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/neonavigation_common/CMakeLists.txt
+++ b/neonavigation_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(neonavigation_common)
 
 set(CATKIN_DEPENDS

--- a/neonavigation_common/CMakeLists.txt
+++ b/neonavigation_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(neonavigation_common)
 
 set(CATKIN_DEPENDS

--- a/neonavigation_launch/CMakeLists.txt
+++ b/neonavigation_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(neonavigation_launch)
 
 find_package(catkin REQUIRED)

--- a/neonavigation_launch/CMakeLists.txt
+++ b/neonavigation_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(neonavigation_launch)
 
 find_package(catkin REQUIRED)

--- a/obj_to_pointcloud/CMakeLists.txt
+++ b/obj_to_pointcloud/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(obj_to_pointcloud)
 
 set(CATKIN_DEPENDS

--- a/obj_to_pointcloud/CMakeLists.txt
+++ b/obj_to_pointcloud/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(obj_to_pointcloud)
 
 set(CATKIN_DEPENDS

--- a/planner_cspace/CMakeLists.txt
+++ b/planner_cspace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(planner_cspace)
 
 set(CATKIN_DEPENDS

--- a/planner_cspace/CMakeLists.txt
+++ b/planner_cspace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(planner_cspace)
 
 set(CATKIN_DEPENDS

--- a/safety_limiter/CMakeLists.txt
+++ b/safety_limiter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(safety_limiter)
 
 set(CATKIN_DEPENDS

--- a/safety_limiter/CMakeLists.txt
+++ b/safety_limiter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(safety_limiter)
 
 set(CATKIN_DEPENDS

--- a/track_odometry/CMakeLists.txt
+++ b/track_odometry/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(track_odometry)
 
 set(CATKIN_DEPENDS

--- a/track_odometry/CMakeLists.txt
+++ b/track_odometry/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(track_odometry)
 
 set(CATKIN_DEPENDS

--- a/trajectory_tracker/CMakeLists.txt
+++ b/trajectory_tracker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3...3.26)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(trajectory_tracker)
 
 set(CATKIN_DEPENDS

--- a/trajectory_tracker/CMakeLists.txt
+++ b/trajectory_tracker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.3...3.26)
 project(trajectory_tracker)
 
 set(CATKIN_DEPENDS


### PR DESCRIPTION
Allow to use cmake compatibility mode up to 3.26 to avoid error/warning on the latest cmake.
CMake 4.0 dropped 3.5 and marked 3.10 as deprecated.