### PR TITLE
planner_cspace: avoid finishing planning during temporary escape

### DIFF
--- a/planner_cspace/test/test/navigation_rostest.test
+++ b/planner_cspace/test/test/navigation_rostest.test
@@ -7,7 +7,7 @@
   <env name="GCOV_PREFIX" value="/tmp/gcov/planner_cspace_navigation_$(arg antialias_start)_$(arg fast_map_update)_$(arg with_tolerance)_$(arg enable_crowd_mode)" />
   <param name="neonavigation_compatible" value="1" />
 
-  <test test-name="test_navigate_$(arg antialias_start)_$(arg fast_map_update)_$(arg with_tolerance)_$(arg enable_crowd_mode)" pkg="planner_cspace" type="test_navigate" time-limit="280.0">
+  <test test-name="test_navigate_$(arg antialias_start)_$(arg fast_map_update)_$(arg with_tolerance)_$(arg enable_crowd_mode)" pkg="planner_cspace" type="test_navigate" time-limit="260.0">
     <param name="enable_crowd_mode" value="$(arg enable_crowd_mode)" />
   </test>
 


### PR DESCRIPTION
When the temporary escape mode is triggered during `PlannerStatus::FINISHING` state, the planner treated arrival to the temporary goal as reaching the final goal.
Clear the `PlannerStatus::FINISHING` state when setting temporary escape goal to avoid this.

As the `PlannerStatus::FINISHING` lasts very short, it's hard to reproduce it in rostest.

This PR also fixes a bug in original goal arrivability check during temporary escape when the original goal is within `esc_range_min`.